### PR TITLE
Add protocol schema support

### DIFF
--- a/Sources/SwiftAvroCore/AvroError.swift
+++ b/Sources/SwiftAvroCore/AvroError.swift
@@ -27,6 +27,8 @@ public enum AvroSchemaDecodingError: Error {
     /// must pass `partial: true` during encoding if you wish to explicitly ignore
     /// missing required fields.
     case unknownSchemaJsonFormat
+    case unnamedSchema
+    case emptyType
 }
 //}
 /// Describes errors that can occur when decoding a message from binary format.

--- a/Sources/SwiftAvroCore/Codable/AvroDecodable.swift
+++ b/Sources/SwiftAvroCore/Codable/AvroDecodable.swift
@@ -285,6 +285,12 @@ fileprivate struct AvroKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContai
             for field in fields {
                 self.schemaMap[field.name] = field.type
             }
+        /*case .errorSchema(_):
+            self.schemaMap["fields"] = schema.findSchema(name: "fields")*/
+        case .protocolSchema(_):
+            self.schemaMap["messages"] = schema.findSchema(name: "messages")
+        case .messageSchema(_):
+            self.schemaMap["request"] = schema.findSchema(name: "request")
         default: self.schemaMap[schema.getName()!] = schema
         }
         self.codingPath = decoder.codingPath

--- a/Sources/SwiftAvroCore/Codable/AvroDecodable.swift
+++ b/Sources/SwiftAvroCore/Codable/AvroDecodable.swift
@@ -44,12 +44,12 @@ final class AvroDecoder {
         }
     }
     
-    func decode<K: Decodable, T: Decodable>(_ type: [K:T].Type, from data: Data) throws -> [K:T] {
+    /*func decode<K: Decodable, T: Decodable>(_ type: [K:T].Type, from data: Data) throws -> [K:T] {
         return try data.withUnsafeBytes{ (pointer: UnsafePointer<UInt8>) in
             let decoder = try AvroBinaryDecoder(schema: schema, pointer: pointer, size: data.count)
             return try [K:T](decoder: decoder)
         }
-    }
+    }*/
 }
 
 final class AvroBinaryDecoder: Decoder {
@@ -89,11 +89,11 @@ final class AvroBinaryDecoder: Decoder {
         return try T(from: self)
     }
     
-    fileprivate func decode<MK: Decodable, T: Decodable>(type: [MK: T].Type) throws -> [MK:T] {
+   /* fileprivate func decode<MK: Decodable, T: Decodable>(type: [MK: T].Type) throws -> [MK:T] {
         let infoKey = CodingUserInfoKey(rawValue: "decodeOption")!
         self.userInfo[infoKey] = self
         return try [MK:T](decoder: self)
-    }
+    }*/
 }
 
 fileprivate struct AvroKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
@@ -255,7 +255,13 @@ fileprivate struct AvroKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContai
         let innerDecoder = try! AvroBinaryDecoder(other: decoder, schema: innerSchema)
         return try type.init(from: innerDecoder)
     }
-
+    func decode<MK:Decodable,T:Decodable>(_ type: [MK:T].Type, forKey key:K) throws -> [MK:T] {
+        if let currentSchema = schemaMap[key.stringValue] {
+            let innerDecoder = try AvroBinaryDecoder(other: decoder, schema: currentSchema)
+            return try innerDecoder.decode(type)
+        }
+        return try type.init(from: decoder)
+    }
     func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
         return KeyedDecodingContainer(AvroKeyedDecodingContainer<NestedKey>(decoder: decoder, schema: schema(key)))
     }
@@ -542,13 +548,42 @@ fileprivate struct InvalidResponseFormat: Error {}
 protocol AvroDecodable: Decodable {
     init(decoder: AvroBinaryDecoder) throws
 }
-public extension KeyedDecodingContainer {
-    func decode<MK: Decodable, T: Decodable>(
-        _ type: [MK : T].Type, forKey key: Key) throws -> [MK : T]
+
+
+/*public extension SingleValueDecodingContainer {
+    func decode<MK: Decodable, T: Decodable>(_ type: [MK : T].Type, forKey key: Key) throws -> [MK : T]
     {
-    guard try self.contains(key) && !self.decodeNil(forKey: key)
-    else { throw BinaryDecodingError.malformedAvro }
-        return try self.decode(type.self, forKey: key)
+        guard try self.contains(key) && !self.decodeNil(forKey: key) else {
+            throw BinaryDecodingError.malformedAvro
+        }
+        var re = [MK : T]()
+    
+        if var container = try? self.nestedUnkeyedContainer(forKey: key) {
+            if let count = container.count {
+                guard count % 2 == 0 else {
+                    throw DecodingError.dataCorrupted(
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "Expected collection of key-value pairs; encountered odd-length array instead."))
+                }
+            }
+            
+            while !container.isAtEnd {
+                
+                let k = try container.decode(MK.self)
+                
+                guard !container.isAtEnd else {
+                    throw DecodingError.dataCorrupted(
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "Unkeyed container reached end before value in key-value pair."))
+                }
+                
+                let value = try container.decode(T.self)
+                re[k] = value
+            }
+        }
+        return re
     }
 }
 extension Dictionary: AvroDecodable where Key : Decodable, Value : Decodable {
@@ -582,5 +617,179 @@ extension Dictionary: AvroDecodable where Key : Decodable, Value : Decodable {
             let value = try container.decode(Value.self)
             self[key] = value
         }
+    }*/
+    /*init(decoder: Decoder) throws {
+        self.init()
+        
+        // Decode as an array of key-value pairs.
+        var container = try! decoder.unkeyedContainer()
+    
+        // Count of key-value pairs should be even number
+        if let count = container.count {
+            guard count % 2 == 0 else {
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Expected collection of key-value pairs; encountered odd-length array instead."))
+            }
+        }
+        
+        while !container.isAtEnd {
+            
+            let key = try container.decode(Key.self)
+            
+            guard !container.isAtEnd else {
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Unkeyed container reached end before value in key-value pair."))
+            }
+            
+            let value = try container.decode(Value.self)
+            self[key] = value
+        }
+    }
+}*/
+struct JSONCodingKeys: CodingKey {
+    var stringValue: String
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    var intValue: Int?
+    //var shemaValue: AvroSchema.MessageSchema?
+
+    init?(intValue: Int) {
+        self.init(stringValue: "\(intValue)")
+        self.intValue = intValue
     }
 }
+
+extension KeyedDecodingContainer {
+/*
+    func decode<T:Codable>(_ type: Dictionary<String, T>.Type, formKey key: K) throws -> Dictionary<String, T> {
+        var container = try self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
+        return try container.decode(type)
+        //var container = try self.nestedUnkeyedContainer(forKey: key)
+            //return try container.decode1(type)
+    }
+
+ func decode<T:Codable>(_ type: T.Type) throws -> T {
+        // var container = try self.nestedUnkeyedContainer(forKey: key)
+     return try decode(type.self)
+ }
+ 
+ func decode<T:Codable>(_ type: Array<T>.Type, forKey key: K) throws -> Array<T> {
+     var container = try self.nestedUnkeyedContainer(forKey: key)
+     return try container.decode(type)
+ }
+
+    func decodeIfPresent<T:Codable>(_ type: Array<T>.Type, forKey key: K) throws -> Array<T>? {
+        guard contains(key) else {
+            return nil
+        }
+        var container = try self.nestedUnkeyedContainer(forKey: key)
+        return try container.decode(type)
+    }
+ */
+    func decodeIfPresent<T:Codable>(_ type: [String: T].Type, forKey key: K) throws -> [String: T]? {
+        guard contains(key) else {
+            return nil
+        }
+        let innercontainer = try self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
+        var dictionary = [String: T]()
+        let ks = innercontainer.allKeys
+        for k in ks {
+            //if let innercontainer = try? self.nestedContainer(keyedBy: T.self, forKey: key) {
+            if let  v = try? innercontainer.decodeIfPresent(type.Value.self,forKey: k){
+                //if let v = try? T(from: de) {
+                    dictionary[key.stringValue] = v
+                }
+            //}
+           // }
+        }
+        return dictionary
+    }
+    func decodeIfPresent(_ type: AvroSchema.MessageSchema.Type, forKey key: K) throws -> AvroSchema.MessageSchema? {
+        guard contains(key) else {
+            return nil
+        }
+        if let de = try? self.superDecoder(forKey: key) {
+            return try AvroSchema.MessageSchema.init(from: de)
+        }
+        return nil
+    }
+}
+
+/*
+extension UnkeyedDecodingContainer {
+    mutating func decode2<T:Codable>(_ type: Array<T>.Type) throws -> Array<T> {
+            var array: [T] = []
+        let de = try? self.superDecoder(){
+            while isAtEnd == false {
+                if let nestedDictionary = try? T.init(from: de) {
+                    array.append(nestedDictionary)
+                }
+            }
+        }
+        return array
+    }
+}
+   
+    mutating func decode1<T:Codable>(_ type: Dictionary<String, T>.Type) throws -> Dictionary<String, T> {
+
+        //let nestedContainer = try self.nestedContainer(keyedBy: JSONCodingKeys.self)
+        var ret = Dictionary<String, T>()
+        while !self.isAtEnd {
+            let k = try decode(type.Key) as String
+            let v = try decode(type.Value) as T
+            ret[k] = v
+        }
+        return ret
+    }
+}
+
+
+*/
+//@propertyWrapper
+/*public struct DictionaryWrapper<Key: Hashable & RawRepresentable, Value: Codable>: Codable where Key.RawValue: Codable & Hashable {
+  public var wrappedValue: [Key: Value]
+
+
+  public init() {
+    wrappedValue = [:]
+  }
+
+  public init(wrappedValue: [Key: Value]) {
+    self.wrappedValue = wrappedValue
+  }
+
+  public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: JSONCodingKeys.self)
+      for k in container.allKeys {
+          let aa = try? container.decodeIfPresent([String:AvroSchema.MessageSchema].self, forKey: k)
+          print(aa)
+      }
+      self.init()
+   
+    let rawKeyedDictionary = try container.decode([Key.RawValue: Value].self)
+
+    
+    for (rawKey, value) in rawKeyedDictionary {
+      guard let key = Key(rawValue: rawKey) else {
+        throw DecodingError.dataCorruptedError(
+          in: container,
+          debugDescription: "Invalid key: cannot initialize '\(Key.self)' from invalid '\(Key.RawValue.self)' value '\(rawKey)'")
+      }
+      wrappedValue[key] = value
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    let rawKeyedDictionary = Dictionary(uniqueKeysWithValues: wrappedValue.map { ($0.rawValue, $1) })
+    var container = encoder.singleValueContainer()
+    try container.encode(rawKeyedDictionary)
+  }
+}*/
+

--- a/Sources/SwiftAvroCore/Schema/AvroSchema+Codable.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema+Codable.swift
@@ -107,49 +107,43 @@ extension AvroSchema  {
             /// for simplicity, the type of current schema can be guessed from the required field such as:
             /// fields for record, sybmols for enum, items for array, values for map and size for fixed.
             /// the name and type correction and namespace filling are delayed to validate step for naming schemas.
-            if container.contains(.fields){
+            if container.contains(.error){
+                var param = try ErrorSchema(from: decoder)
+                param.validate(typeName: Types.error.rawValue)
+                self = .errorSchema(param)
+            }else if container.contains(.fields){
                 var param = try RecordSchema(from: decoder)
                 param.validate(typeName: Types.record.rawValue)
                 self = .recordSchema(param)
-                return
             } else if container.contains(.symbols){
                 var schema = try EnumSchema(from: decoder)
                 schema.validate(typeName: Types.enums.rawValue)
                 self = .enumSchema(schema)
-                return
             } else if container.contains(.items){
                 let schema = try ArraySchema(from: decoder)
                 self = .arraySchema(schema)
-                return
             } else if container.contains(.values){
                 let schema = try MapSchema(from: decoder)
                 self = .mapSchema(schema)
-                return
             } else if container.contains(.size){
                 var schema = try FixedSchema(from: decoder)
                 schema.validate(typeName: Types.fixed.rawValue)
                 self = .fixedSchema(schema)
-                return
             } else if container.contains(.protocolName) {
                 var schema = try ProtocolSchema(from: decoder)
                 try schema.validate(typeName: Types.protocolName.rawValue)
                 self = .protocolSchema(schema)
-                return
             } else if container.contains(.messages) {
                 let schema = try MessageSchema(from: decoder)
-                //try schema.validate(typeName: Types.protocolName.rawValue)
                 self = .messageSchema(schema)
-                return
             } else if container.contains(.type) {
                     /// if the json schema use standard type, decode directly.
                 if let type = try container.decodeIfPresent(Types.self, forKey: .type) {
                     switch type {
                     case .null:
                         self = .nullSchema
-                       // return
                     case .boolean:
                         self = .booleanSchema
-                       // return
                     case .int:
                         let logicalType = try container.decodeIfPresent(LogicalType.self, forKey: .logicalType)
                         if let logicType = logicalType {
@@ -157,7 +151,6 @@ extension AvroSchema  {
                         } else {
                             self = .intSchema(IntSchema())
                         }
-                       // return
                     case .long:
                         let logicalType = try container.decodeIfPresent(LogicalType.self, forKey: .logicalType)
                         if let logicType = logicalType {
@@ -165,16 +158,12 @@ extension AvroSchema  {
                         } else {
                             self = .longSchema(IntSchema(isLong: true))
                         }
-                     //   return
                     case .float:
                         self = .floatSchema
-                       // return
                     case .double:
                         self = .doubleSchema
-                       // return
                     case .string:
                         self = .stringSchema
-                      //  return
                     case .bytes:
                         let logicalType = try container.decodeIfPresent(LogicalType.self, forKey: .logicalType)
                         if let logicType = logicalType {
@@ -186,38 +175,30 @@ extension AvroSchema  {
                         } else {
                             self = .bytesSchema(BytesSchema())
                         }
-                    //    return
-                    case .enums:
+                   case .enums:
                         var param = try EnumSchema(from: decoder)
                         param.validate(typeName: type.rawValue)
                         self = .enumSchema(param)
-                       // return
                     case .array:
                         let param = try ArraySchema(from: decoder)
                         self = .arraySchema(param)
-                      //  return
                     case .map:
                         let param = try MapSchema(from: decoder)
                         self = .mapSchema(param)
-                       // return
-                    case .fixed:
+                         case .fixed:
                         var param = try FixedSchema(from: decoder)
                         param.validate(typeName: type.rawValue)
                         self = .fixedSchema(param)
-                     //   return
                     case .union:
                         let param = try UnionSchema(from: decoder)
                         self = .unionSchema(param)
-                       // return
                     case .record:
                         var param = try RecordSchema(from: decoder)
                         param.validate(typeName: type.rawValue)
                         self = .recordSchema(param)
-                      //  return
                     case .field:
                         let param = try FieldSchema(from: decoder)
-                        self = .fieldSchema(param)
-                      //  return
+                        self = .fieldSchema(param)/**/
                     default:
                         self = .invalidSchema
                     }

--- a/Sources/SwiftAvroCore/Schema/AvroSchema+Codable.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema+Codable.swift
@@ -393,15 +393,8 @@ extension AvroSchema.ProtocolSchema {
         if "protocol" != typeName {
             throw AvroSchemaDecodingError.emptyType
         }
-        /*if protocolName == "" {
-            protocolName = typeName
-        }*/
         if let ts = types {
             for t in ts {
-               //guard let _ = t as? NameSchemaProtocol else {
-                 
-                //throw AvroSchemaDecodingError.unnamedSchema
-               // }
                 if t.getName() == "" {
                     throw AvroSchemaDecodingError.unnamedSchema
                 }
@@ -439,12 +432,6 @@ extension AvroSchema.ProtocolSchema {
                 self.doc = ""
             }
             if let messages = try? container.decodeIfPresent(Dictionary<String, AvroSchema.Message>.self,forKey: .messages) {
-                /*var messageMap = Dictionary<String, AvroSchema.MessageSchema>()
-                if let types = self.types {
-                    for (k,message) in messages! {
-                        messageMap[k] = try AvroSchema.MessageSchema.init(from: message, types:types)
-                    }
-                }*/
                 self.messages = messages
             } else {
                 self.messages = nil

--- a/Sources/SwiftAvroCore/Schema/AvroSchema+Equatable.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema+Equatable.swift
@@ -234,7 +234,7 @@ extension AvroSchema.BytesSchema {
 
 extension AvroSchema.ProtocolSchema {
     public static func == (lhs: AvroSchema.ProtocolSchema, rhs: AvroSchema.ProtocolSchema) -> Bool {
-        if (lhs.protocolName != rhs.protocolName) {return false}
+        if (lhs.type != rhs.type) {return false}
         if (lhs.namespace != rhs.namespace) {return false}
         if lhs.types?.count != rhs.types?.count {return false}
         if let types = lhs.types {
@@ -321,12 +321,12 @@ extension AvroSchema {
             hasher.combine(schema.name)
         case .protocolSchema(let schema):
             hasher.combine(schema.namespace)
-            hasher.combine(schema.protocolName)
+            hasher.combine(schema.type)
         case .messageSchema(let scheme):
-            hasher.combine(scheme.response.getName())
-            for request in scheme.request {
-                hasher.combine(request.name)
-            }
+            hasher.combine(scheme.response)
+           // for request in scheme.request {
+             //   hasher.combine(request.name)
+            //}
         }
     }
     
@@ -620,13 +620,32 @@ extension AvroSchema {
             return nil
         }
     }
-    func getMessages() -> [String:MessageSchema]? {
+    /*func getMessages() -> [String: MessageSchema]? {
         switch self {
         case .protocolSchema(let p):
             return p.messages
         default:
             return nil
         }
+    }*/
+    func getRequestSchemas(messageName: String) -> [AvroSchema]? {
+        switch self {
+        case .protocolSchema(let p):
+            if let message = p.messages?[messageName],let types = p.types {
+                if let requests = message.request{
+                    var requestSchemas = [AvroSchema]()
+                    for s in requests {
+                        if let t = types.first(where:{$0.getName() == s.name}) {
+                            requestSchemas.append(t)
+                        }
+                    }
+                    return requestSchemas
+                }
+            }
+        default:
+            return nil
+        }
+        return nil
     }
     func getProtocolTypes() -> [AvroSchema] {
         var innerTypes: [AvroSchema] = []

--- a/Sources/SwiftAvroCore/Schema/AvroSchema+Equatable.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema+Equatable.swift
@@ -620,45 +620,12 @@ extension AvroSchema {
             return nil
         }
     }
-    /*func getMessages() -> [String: MessageSchema]? {
+    func getError() -> ErrorSchema? {
         switch self {
-        case .protocolSchema(let p):
-            return p.messages
+        case .errorSchema(let p):
+            return p
         default:
             return nil
-        }
-    }*/
-    func getRequestSchemas(messageName: String) -> [AvroSchema]? {
-        switch self {
-        case .protocolSchema(let p):
-            if let message = p.messages?[messageName],let types = p.types {
-                if let requests = message.request{
-                    var requestSchemas = [AvroSchema]()
-                    for s in requests {
-                        if let t = types.first(where:{$0.getName() == s.name}) {
-                            requestSchemas.append(t)
-                        }
-                    }
-                    return requestSchemas
-                }
-            }
-        default:
-            return nil
-        }
-        return nil
-    }
-    func getProtocolTypes() -> [AvroSchema] {
-        var innerTypes: [AvroSchema] = []
-        switch self {
-        case .protocolSchema(let p):
-            if let types = p.types {
-                for t in types {
-                    innerTypes.append(t)
-                }
-            }
-            return innerTypes
-        default:
-            return []
         }
     }
 }

--- a/Sources/SwiftAvroCore/Schema/AvroSchema.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema.swift
@@ -307,7 +307,7 @@ public struct ProtocolSchema : Equatable, NameSchemaProtocol {
     var name: String?
     var namespace: String? //{get set}
     var types: [AvroSchema]?
-    var messages: Dictionary<String,Message>?
+    var messages: Dictionary<String, MessageSchema>?
     var aliases: Set<String>? //{get set}
     let doc: String? //{get set}
     enum CodingKeys: String, CodingKey {
@@ -327,7 +327,7 @@ public struct MessageSchema : Equatable, Codable {
     let doc: String?
     let request: [AvroSchema]?
     let response: AvroSchema?
-    let errors: ErrorSchema?
+    let errors: [ErrorSchema]?
     let optional: Bool?
     var resolution: ResolutionMethod = .useDefault
 }

--- a/Sources/SwiftAvroCore/Schema/AvroSchema.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema.swift
@@ -307,7 +307,7 @@ public struct ProtocolSchema : Equatable, NameSchemaProtocol {
     var name: String?
     var namespace: String? //{get set}
     var types: [AvroSchema]?
-    var messages: Dictionary<String, MessageSchema>?
+    var messages: Dictionary<String, Message>?
     var aliases: Set<String>? //{get set}
     let doc: String? //{get set}
     enum CodingKeys: String, CodingKey {
@@ -315,14 +315,14 @@ public struct ProtocolSchema : Equatable, NameSchemaProtocol {
     }
     var resolution: ResolutionMethod = .useDefault
 }
-    struct Message : Equatable, Codable {
-       let doc: String?
-       let request: [RequestType]?
-       let response: String?
-       let errors: [String]?
-       let optional: Bool?
-       var resolution: ResolutionMethod = .useDefault
-    }
+struct Message : Equatable, Codable {
+   let doc: String?
+   let request: [RequestType]?
+   let response: String?
+   let errors: [String]?
+   let optional: Bool?
+   var resolution: ResolutionMethod = .useDefault
+}
 public struct MessageSchema : Equatable, Codable {
     let doc: String?
     let request: [AvroSchema]?

--- a/Sources/SwiftAvroCore/Schema/AvroSchema.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema.swift
@@ -116,9 +116,6 @@ public enum AvroSchema: Codable, Hashable {
         case .fieldsSchema:
             return "fields"
         case .fieldSchema(let param):
-            if param.name.isEmpty {
-                return param.name
-            }
             return param.name
         /// rpc type
         case .protocolSchema(let param):

--- a/Sources/SwiftAvroCore/Schema/AvroSchema.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema.swift
@@ -58,7 +58,7 @@ public enum AvroSchema: Codable, Hashable {
         /// rpc types
         protocolName = "protocol", message, errors,
         /// private type
-        field,
+        field,error,
         /// invalid type
         invalid
     }

--- a/Tests/SwiftAvroCoreTests/AvroEncodableTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroEncodableTest.swift
@@ -420,7 +420,49 @@ class AvroEnodableTest: XCTestCase {
         XCTAssertEqual(json, expected)
     }
     
-
+    func testProtocol() {
+        struct Model: Codable {
+            let protocolName: String
+            let requestName: String
+            let requestType: [UInt8]
+            let parameter: [Int32]
+            let parameter2: [String: Int32]
+        }
+        let schemaJson1 = """
+{
+  "namespace": "com.acme",
+  "protocol": "HelloWorld",
+  "doc": "Protocol Greetings",
+  "types": [
+     {"name": "Greeting", "type": "record", "fields": [
+       {"name": "message", "type": "string"}]},
+     {"name": "Curse", "type": "error", "fields": [
+       {"name": "message", "type": "string"}]}
+  ],
+  "messages": {
+    "hello": {
+       "doc": "Say hello.",
+       "request": [{"name": "greeting", "type": "Greeting" }],
+       "response": "Greeting",
+       "errors": ["Curse"]
+    }
+  }
+}
+"""
+        //let expected: Data = Data([0x54, 0x0a, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x01, 0x02, 0x03, 0x04, 0x04, 0x02, 0x04, 0x0, 0x02, 0x06, 0x66, 0x6f, 0x6f, 0x04, 0])
+        let avro = Avro()
+        let schema = avro.decodeSchema(schema: schemaJson1)!
+        let types = schema.getProtocolTypes()
+        //let schema = Avro().decodeSchema(schema: schemaJson)!
+        //let model = Model(protocolName: "testProtocol", requestName: "hello", requestType: [1,2,3,4], parameter: [1,2], parameter2: ["foo": 2])
+        //let jsonencoder = AvroJSONEncoder(schema: schema)
+        //try? jsonencoder.encode(model)
+       // let encoder = AvroEncoder()
+        //let data = try! encoder.encode(model, schema: schema)
+        
+       // XCTAssertEqual(data, expected)
+    }
+    
     func testPerformanceExample() {
         // This is an example of a performance test case.
         self.measure {

--- a/Tests/SwiftAvroCoreTests/AvroEncodableTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroEncodableTest.swift
@@ -21,6 +21,7 @@ import XCTest
 class AvroEnodableTest: XCTestCase {
     var schema: AvroSchema = AvroSchema()
     override func setUp() {
+        return
         // Put setup code here. This method is called before the invocation of each test method in the class.
         let schemaJson = """
 {"type":"record",
@@ -418,49 +419,6 @@ class AvroEnodableTest: XCTestCase {
 
         let expected: String = "{\"message\":{\"requestName\":\"hello\",\"parameter2\":{\"foo\":2},\"requestId\":42,\"parameter\":[1,2],\"requestType\":\"\\u0001\\u0002\\u0003\\u0004\"},\"name\":\"test\"}"
         XCTAssertEqual(json, expected)
-    }
-    
-    func testProtocol() {
-        struct Model: Codable {
-            let protocolName: String
-            let requestName: String
-            let requestType: [UInt8]
-            let parameter: [Int32]
-            let parameter2: [String: Int32]
-        }
-        let schemaJson1 = """
-{
-  "namespace": "com.acme",
-  "protocol": "HelloWorld",
-  "doc": "Protocol Greetings",
-  "types": [
-     {"name": "Greeting", "type": "record", "fields": [
-       {"name": "message", "type": "string"}]},
-     {"name": "Curse", "type": "error", "fields": [
-       {"name": "message", "type": "string"}]}
-  ],
-  "messages": {
-    "hello": {
-       "doc": "Say hello.",
-       "request": [{"name": "greeting", "type": "Greeting" }],
-       "response": "Greeting",
-       "errors": ["Curse"]
-    }
-  }
-}
-"""
-        //let expected: Data = Data([0x54, 0x0a, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x01, 0x02, 0x03, 0x04, 0x04, 0x02, 0x04, 0x0, 0x02, 0x06, 0x66, 0x6f, 0x6f, 0x04, 0])
-        let avro = Avro()
-        let schema = avro.decodeSchema(schema: schemaJson1)!
-        let types = schema.getProtocolTypes()
-        //let schema = Avro().decodeSchema(schema: schemaJson)!
-        //let model = Model(protocolName: "testProtocol", requestName: "hello", requestType: [1,2,3,4], parameter: [1,2], parameter2: ["foo": 2])
-        //let jsonencoder = AvroJSONEncoder(schema: schema)
-        //try? jsonencoder.encode(model)
-       // let encoder = AvroEncoder()
-        //let data = try! encoder.encode(model, schema: schema)
-        
-       // XCTAssertEqual(data, expected)
     }
     
     func testPerformanceExample() {

--- a/Tests/SwiftAvroCoreTests/AvroEncodableTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroEncodableTest.swift
@@ -21,7 +21,6 @@ import XCTest
 class AvroEnodableTest: XCTestCase {
     var schema: AvroSchema = AvroSchema()
     override func setUp() {
-        return
         // Put setup code here. This method is called before the invocation of each test method in the class.
         let schemaJson = """
 {"type":"record",

--- a/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
@@ -352,6 +352,47 @@ class AvroSchemaCodingTest: XCTestCase {
         XCTAssertTrue(schema!.isRecord())
     }
 
+    
+    func testProtocol() {
+        struct Model: Codable {
+            let protocolName: String
+            let requestName: String
+            let requestType: [UInt8]
+            let parameter: [Int32]
+            let parameter2: [String: Int32]
+        }
+        let schemaJson1 = """
+{
+  "namespace": "com.acme",
+  "protocol": "HelloWorld",
+  "doc": "Protocol Greetings",
+  "types": [
+     {"name": "Greeting", "type": "record", "fields": [{"name": "message", "type": "string"}]},
+     {"name": "Curse", "type": "error", "fields": [{"name": "message", "type": "string"}]}],
+  "messages": {
+    "hello": {
+       "doc": "Say hello.",
+       "request": [{"name": "greeting", "type": "Greeting" }],
+       "response": "Greeting",
+       "errors": ["Curse"]
+    }
+  }
+}
+"""
+        //
+        //let expected: Data = Data([0x54, 0x0a, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x01, 0x02, 0x03, 0x04, 0x04, 0x02, 0x04, 0x0, 0x02, 0x06, 0x66, 0x6f, 0x6f, 0x04, 0])
+        let avro = Avro()
+        let schema = avro.decodeSchema(schema: schemaJson1)!
+        let types = schema.getProtocolTypes()
+        //let schema = Avro().decodeSchema(schema: schemaJson)!
+        //let model = Model(protocolName: "testProtocol", requestName: "hello", requestType: [1,2,3,4], parameter: [1,2], parameter2: ["foo": 2])
+        //let jsonencoder = AvroJSONEncoder(schema: schema)
+        //try? jsonencoder.encode(model)
+       // let encoder = AvroEncoder()
+        //let data = try! encoder.encode(model, schema: schema)
+        
+       // XCTAssertEqual(data, expected)
+    }
     func testPerformanceExample() {
         // This is an example of a performance test case.
         self.measure {

--- a/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
@@ -378,14 +378,6 @@ class AvroSchemaCodingTest: XCTestCase {
         let newSchema = Avro().decodeSchema(schema: encoded!)!
         let encoded2 = try? Avro().encodeSchema(schema: newSchema)
         XCTAssertEqual(encoded, encoded2)
-
-        /*let model = Model(protocolName: "testProtocol", requestName: "hello", requestType: [1,2,3,4], parameter: [1,2], parameter2: ["foo": 2])
-        let jsonencoder = AvroJSONEncoder(schema: schema)
-        try? jsonencoder.encode(model)
-        let encoder = AvroEncoder()
-        let data = try! encoder.encode(model, schema: schema)
-        
-        XCTAssertEqual(data, expected)*/
     }
     func testPerformanceExample() {
         // This is an example of a performance test case.

--- a/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
@@ -344,7 +344,7 @@ class AvroSchemaCodingTest: XCTestCase {
         XCTAssertTrue(schema!.isRecord())
     }
 
-    
+    /*
     func testProtocol() {
         struct Model: Codable {
             let protocolName: String
@@ -384,7 +384,7 @@ class AvroSchemaCodingTest: XCTestCase {
         //let data = try! encoder.encode(model, schema: schema)
         
        // XCTAssertEqual(data, expected)
-    }
+    }*/
     func testPerformanceExample() {
         // This is an example of a performance test case.
         self.measure {

--- a/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
@@ -339,9 +339,10 @@ class AvroSchemaCodingTest: XCTestCase {
 ]
 }
 """
-        let schema = testTarget!.decodeSchema(schema: sample)
+        let schema = testTarget!.decodeSchema(schema: sample)!
+        let schema2 = try? testTarget!.encodeSchema(schema: schema)
         XCTAssertNotNil(schema)
-        XCTAssertTrue(schema!.isRecord())
+        XCTAssertTrue(schema.isRecord())
     }
 
     func testProtocol() {
@@ -373,9 +374,11 @@ class AvroSchemaCodingTest: XCTestCase {
         //let expected: Data = Data([0x54, 0x0a, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x01, 0x02, 0x03, 0x04, 0x04, 0x02, 0x04, 0x0, 0x02, 0x06, 0x66, 0x6f, 0x6f, 0x04, 0])
         let schema = Avro().decodeSchema(schema: schemaJson1)!
         let encoded = try? Avro().encodeSchema(schema: schema)
+        print(String(data: encoded!, encoding: .utf8)!)
         let newSchema = Avro().decodeSchema(schema: encoded!)!
-        print(newSchema)
-       // XCTAssertEqual(schema, newSchema)
+        let encoded2 = try? Avro().encodeSchema(schema: newSchema)
+        XCTAssertEqual(encoded, encoded2)
+
         /*let model = Model(protocolName: "testProtocol", requestName: "hello", requestType: [1,2,3,4], parameter: [1,2], parameter2: ["foo": 2])
         let jsonencoder = AvroJSONEncoder(schema: schema)
         try? jsonencoder.encode(model)

--- a/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
@@ -344,7 +344,6 @@ class AvroSchemaCodingTest: XCTestCase {
         XCTAssertTrue(schema!.isRecord())
     }
 
-    /*
     func testProtocol() {
         struct Model: Codable {
             let protocolName: String
@@ -371,20 +370,20 @@ class AvroSchemaCodingTest: XCTestCase {
   }
 }
 """
-        //
         //let expected: Data = Data([0x54, 0x0a, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x01, 0x02, 0x03, 0x04, 0x04, 0x02, 0x04, 0x0, 0x02, 0x06, 0x66, 0x6f, 0x6f, 0x04, 0])
-        let avro = Avro()
-        let schema = avro.decodeSchema(schema: schemaJson1)!
-        let types = schema.getProtocolTypes()
-        //let schema = Avro().decodeSchema(schema: schemaJson)!
-        //let model = Model(protocolName: "testProtocol", requestName: "hello", requestType: [1,2,3,4], parameter: [1,2], parameter2: ["foo": 2])
-        //let jsonencoder = AvroJSONEncoder(schema: schema)
-        //try? jsonencoder.encode(model)
-       // let encoder = AvroEncoder()
-        //let data = try! encoder.encode(model, schema: schema)
+        let schema = Avro().decodeSchema(schema: schemaJson1)!
+        let encoded = try? Avro().encodeSchema(schema: schema)
+        let newSchema = Avro().decodeSchema(schema: encoded!)!
+        print(newSchema)
+       // XCTAssertEqual(schema, newSchema)
+        /*let model = Model(protocolName: "testProtocol", requestName: "hello", requestType: [1,2,3,4], parameter: [1,2], parameter2: ["foo": 2])
+        let jsonencoder = AvroJSONEncoder(schema: schema)
+        try? jsonencoder.encode(model)
+        let encoder = AvroEncoder()
+        let data = try! encoder.encode(model, schema: schema)
         
-       // XCTAssertEqual(data, expected)
-    }*/
+        XCTAssertEqual(data, expected)*/
+    }
     func testPerformanceExample() {
         // This is an example of a performance test case.
         self.measure {


### PR DESCRIPTION
Implement the protocol schema in Avro. This schema is used for RPC session handshake. The protocol schema not only includes the current schemas, but several special fields that no standard schema support, so it make sense to include it as a separate schema in the core module instead of the RPC module in development. 