### PR TITLE
Make NullCode.init public

### DIFF
--- a/Sources/SwiftAvroCore/FileObject/NullCodec.swift
+++ b/Sources/SwiftAvroCore/FileObject/NullCodec.swift
@@ -59,7 +59,7 @@ public struct NullCodec: CodecProtocol {
         return codec
     }
     
-    init(codecName: String) {
+    public init(codecName: String) {
         self.codec = codecName
     }
 }


### PR DESCRIPTION
By making this change I'm able to follow the example decoding instructions in the readme. fixes #24 