### PR TITLE
SwiftAvroCore 1.2

### DIFF
--- a/Codable/LogicalTypeConverter.swift
+++ b/Codable/LogicalTypeConverter.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Internal utility for converting between Avro binary representations and Swift Foundation types.
+internal enum LogicalTypeConverter {
+
+    // MARK: - Decimal
+
+    /// Decodes a decimal from two's complement bytes.
+    static func decodeDecimal(bytes: [UInt8], scale: Int, precision: Int) -> Decimal {
+        let bigInt = bytesToBigInt(bytes)
+        let decimalValue = Decimal(string: "\(bigInt)") ?? 0
+        let divisor = pow(10, scale)
+        return decimalValue / divisor
+    }
+
+    /// Encodes a decimal to two's complement bytes.
+    static func encodeDecimal(_ decimal: Decimal, scale: Int, precision: Int) -> [UInt8] {
+        let multiplier = pow(10, scale)
+        let scaledValue = decimal * multiplier
+        let bigIntString = scaledValue.description.split(separator: ".").first.map(String.init) ?? "0"
+        return bigIntToString(bigIntString)
+    }
+
+    // MARK: - Timestamp Micros
+
+    static func decodeTimestampMicros(_ micros: Int64) -> Date {
+        return Date(timeIntervalSince1970: Double(micros) / 1_000_000.0)
+    }
+
+    static func encodeTimestampMicros(_ date: Date) -> Int64 {
+        return Int64(round(date.timeIntervalSince1970 * 1_000_000.0))
+    }
+
+    // MARK: - Time Millis
+
+    static func decodeTimeMillis(_ millis: Int32) -> Date {
+        let calendar = Calendar.current
+        let midnight = calendar.startOfDay(for: Date())
+        return midnight.addingTimeInterval(TimeInterval(millis) / 1000.0)
+    }
+
+    static func encodeTimeMillis(_ date: Date) -> Int32 {
+        let calendar = Calendar.current
+        let midnight = calendar.startOfDay(for: date)
+        let diff = date.timeIntervalSince(midnight)
+        return Int32(round(diff * 1000.0))
+    }
+
+    // MARK: - Time Micros
+
+    static func decodeTimeMicros(_ micros: Int64) -> Date {
+        let calendar = Calendar.current
+        let midnight = calendar.startOfDay(for: Date())
+        return midnight.addingTimeInterval(TimeInterval(micros) / 1_000_000.0)
+    }
+
+    static func encodeTimeMicros(_ date: Date) -> Int64 {
+        let calendar = Calendar.current
+        let midnight = calendar.startOfDay(for: date)
+        let diff = date.timeIntervalSince(midnight)
+        return Int64(round(diff * 1_000_000.0))
+    }
+
+    // MARK: - Duration
+
+    static func decodeDuration(bytes: [UInt8]) -> TimeInterval {
+        // Duration is 16 bytes nanoseconds.
+        // For simplicity in this core implementation, we handle the lower 8 bytes as the primary value.
+        let nanos = bytesToInt128(bytes)
+        return TimeInterval(nanos) / 1_000_000_000.0
+    }
+
+    static func encodeDuration(_ duration: TimeInterval) -> [UInt8] {
+        let nanos = Int64(round(duration * 1_000_000_000.0))
+        return int128ToBytes(nanos)
+    }
+
+    // MARK: - Helpers
+
+    private static func bytesToBigInt(_ bytes: [UInt8]) -> String {
+        if bytes.isEmpty { return "0" }
+        // Simplification: Convert bytes to a hex string then to decimal.
+        // In a full implementation, this would handle true two's complement for arbitrary lengths.
+        let hex = bytes.map { String(format: "%02x", $0) }.joined()
+        if let val = Int64(hex, radix: 16) { return String(val) }
+        return "0"
+    }
+
+    private static func bigIntToString(_ s: String) -> [UInt8] {
+        // Convert decimal string to bytes.
+        // This is a stub for the complex two's complement binary encoding.
+        return Array(s.utf8)
+    }
+
+    private static func bytesToInt128(_ bytes: [UInt8]) -> Int64 {
+        // Duration is 16 bytes. We extract the Int64 value.
+        return bytes.withUnsafeBytes { $0.load(as: Int64.self) }
+    }
+
+    private static func int128ToBytes(_ val: Int64) -> [UInt8] {
+        var value = val
+        return withUnsafeBytes(of: &value) { Array($0) }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "SwiftAvroCore",
     platforms: [
-        .macOS(.v10_15), // Sets the minimum deployment target to macOS 10.15
-        .iOS(.v16)
+        .macOS(.v10_13),
+        .iOS(.v15)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ SwiftAvroCore implements the core coding functionality required by Apache Avro�
 | **Binary Encoding** | ✅ Full | Supports all primitive and complex types per Avro spec. |
 | **JSON Encoding** | ✅ Full | Implements the Avro JSON wire format. |
 | **Schema Support** | ✅ Full | Supports 1.8.2+ schemas including Unions and Enums. |
-| **Logical Types** | Partial | Supports `date`, `timestamp-millis`, and `uuid`; Decimal and timestamp-micros pending. |
+| **Logical Types** | ✅ Full | Supports `decimal`, `date`, `time-millis`, `time-micros`, `timestamp-millis`, `timestamp-micros`, `duration`, and `uuid`. |
 | **Object Container** | ✅ Full | Implements the data file format with header and blocks. |
 | **IPC/RPC** | ✅ Full | Implements framing, handshakes, and message exchange. |
 | **Fingerprinting** | ✅ Full | Implements the 64-bit Rabin fingerprint. |
-| **Schema Evolution** | ❌ None | Reader/Writer schema resolution is not yet implemented. |
+| **Schema Evolution** | Partial | Supports reader/writer resolution for matching schemas, numeric promotions, unions, records, maps, arrays, fixed, enums, and decimal logical types. |
 | **Compression** | ❌ None | Codecs (deflate, snappy, etc.) provided by `SwiftAvroRpc`. |
 
 It is designed to achieve the following goals:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SwiftAvroCore implements the core coding functionality required by Apache Avro�
 | **Object Container** | ✅ Full | Implements the data file format with header and blocks. |
 | **IPC/RPC** | ✅ Full | Implements framing, handshakes, and message exchange. |
 | **Fingerprinting** | ✅ Full | Implements the 64-bit Rabin fingerprint. |
-| **Schema Evolution** | Partial | Supports reader/writer resolution for matching schemas, numeric promotions, unions, records, maps, arrays, fixed, enums, and decimal logical types. |
+| **Schema Evolution** | ✅ Full | Supports writer/reader decoding with defaults, aliases, field reordering, writer-only field skipping, numeric promotions, unions, records, maps, arrays, fixed, enums, and decimal logical types. |
 | **Compression** | ❌ None | Codecs (deflate, snappy, etc.) provided by `SwiftAvroRpc`. |
 
 It is designed to achieve the following goals:

--- a/Sources/SwiftAvroCore/AvroError.swift
+++ b/Sources/SwiftAvroCore/AvroError.swift
@@ -86,7 +86,7 @@ public enum BinaryDecodingError: Error, Equatable {
 }
 
 /// Describes errors that can occur in Schema Resolution.
-public enum AvroSchemaResolutionError: Error {
+public enum AvroSchemaResolutionError: Error, Equatable {
     case WriterFieldMissingWithoutDefaultValue
     case SchemaMismatch
 }

--- a/Sources/SwiftAvroCore/Codable/AvroDecodable.swift
+++ b/Sources/SwiftAvroCore/Codable/AvroDecodable.swift
@@ -43,6 +43,9 @@ final class AvroDecoder {
             return try data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
                 let pointer = buffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
                 let decoder = try AvroBinaryDecoder(schema: schema, pointer: pointer, size: data.count)
+                if T.self == Date.self, let date = try decoder.decodeLogicalDate(schema: schema) {
+                    return date as! T
+                }
                 return try type.init(from: decoder)
             }
         case .AvroJson:
@@ -101,6 +104,23 @@ final class AvroBinaryDecoder: Decoder {
         try AvroSingleValueDecodingContainer(decoder: self, schema: schema)
     }
 
+    func decodeLogicalDate(schema: AvroSchema) throws -> Date? {
+        switch schema {
+        case .intSchema(let s) where s.logicalType == .date:
+            return LogicalTypeConverter.decodeDate(try primitive.decode() as Int)
+        case .intSchema(let s) where s.logicalType == .timeMillis:
+            return LogicalTypeConverter.decodeTimeMillis(try primitive.decode() as Int32)
+        case .longSchema(let s) where s.logicalType == .timestampMillis:
+            return LogicalTypeConverter.decodeTimestampMillis(try primitive.decode() as Int64)
+        case .longSchema(let s) where s.logicalType == .timestampMicros:
+            return LogicalTypeConverter.decodeTimestampMicros(try primitive.decode() as Int64)
+        case .longSchema(let s) where s.logicalType == .timeMicros:
+            return LogicalTypeConverter.decodeTimeMicros(try primitive.decode() as Int64)
+        default:
+            return nil
+        }
+    }
+
     func decode(schema: AvroSchema) throws -> Any? {
         switch schema {
         case .nullSchema:
@@ -111,11 +131,23 @@ final class AvroBinaryDecoder: Decoder {
 
         case .intSchema(let intSchema):
             if intSchema.logicalType == .date {
-                return Date(timeIntervalSince1970: Double(try primitive.decode() as Int))
+                return LogicalTypeConverter.decodeDate(try primitive.decode() as Int)
+            }
+            if intSchema.logicalType == .timeMillis {
+                return LogicalTypeConverter.decodeTimeMillis(try primitive.decode() as Int32)
             }
             return try primitive.decode() as Int32
 
-        case .longSchema:
+        case .longSchema(let longSchema):
+            if longSchema.logicalType == .timestampMillis {
+                return LogicalTypeConverter.decodeTimestampMillis(try primitive.decode() as Int64)
+            }
+            if longSchema.logicalType == .timestampMicros {
+                return LogicalTypeConverter.decodeTimestampMicros(try primitive.decode() as Int64)
+            }
+            if longSchema.logicalType == .timeMicros {
+                return LogicalTypeConverter.decodeTimeMicros(try primitive.decode() as Int64)
+            }
             return try primitive.decode() as Int64
 
         case .floatSchema:
@@ -124,7 +156,11 @@ final class AvroBinaryDecoder: Decoder {
         case .doubleSchema:
             return try primitive.decode() as Double
 
-        case .bytesSchema:
+        case .bytesSchema(let byteSchema):
+            if byteSchema.logicalType == .decimal {
+                let bytes = try primitive.decode() as [UInt8]
+                return LogicalTypeConverter.decodeDecimal(bytes: bytes, scale: byteSchema.scale ?? 0, precision: byteSchema.precision ?? 0)
+            }
             return try primitive.decode() as [UInt8]
 
         case .stringSchema(_):
@@ -188,7 +224,12 @@ final class AvroBinaryDecoder: Decoder {
 
         case .fixedSchema(let fixedSchema):
             if fixedSchema.logicalType == .duration {
-                return try primitive.decode(fixedSize: fixedSchema.size) as [UInt32]
+                let bytes = try primitive.decode(fixedSize: fixedSchema.size) as [UInt8]
+                return LogicalTypeConverter.decodeDuration(bytes: bytes)
+            }
+            if fixedSchema.logicalType == .decimal {
+                let bytes = try primitive.decode(fixedSize: fixedSchema.size) as [UInt8]
+                return LogicalTypeConverter.decodeDecimal(bytes: bytes, scale: fixedSchema.scale ?? 0, precision: fixedSchema.precision ?? 0)
             }
             return try primitive.decode(fixedSize: fixedSchema.size) as [UInt8]
 
@@ -255,6 +296,11 @@ private struct AvroKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerP
 
     @inlinable func decode<T: Decodable>(_ type: T.Type, forKey key: K) throws -> T {
         let currentSchema = try schema(for: key)
+        if T.self == Date.self {
+            if let date = try decoder.decodeLogicalDate(schema: currentSchema) {
+                return date as! T
+            }
+        }
         switch currentSchema {
         case .fixedSchema:
             var container = try nestedUnkeyedContainer(forKey: key)
@@ -376,6 +422,9 @@ private struct AvroUnkeyedDecodingContainer: UnkeyedDecodingContainer, DecodingH
             // The cast back to T is guaranteed by the upstream `as? AvroDecodable.Type`
             // — `avroDecodable` IS T's metatype, so its initialiser returns a T.
             return try avroDecodable.init(decoder: AvroBinaryDecoder(other: decoder, schema: schema)) as! T
+        }
+        if T.self == Date.self, let date = try decoder.decodeLogicalDate(schema: schema) {
+            return date as! T
         }
         return try type.init(from: AvroBinaryDecoder(other: decoder, schema: schema))
     }
@@ -521,23 +570,25 @@ extension DecodingHelper {
         case .doubleSchema:
             return try decoder.primitive.decode()
         case .intSchema(let intSchema) where intSchema.logicalType == .date:
-            let unixDate = Double(try decoder.primitive.decode() as Int)
-            return unixDate - Date.timeIntervalBetween1970AndReferenceDate
+            return LogicalTypeConverter.decodeDate(try decoder.primitive.decode() as Int).timeIntervalSince1970
         case .intSchema(let intSchema) where intSchema.logicalType == .timeMillis:
-            return Double(try decoder.primitive.decode() as Int)
+            return Double(try decoder.primitive.decode() as Int32)
         case .longSchema(let longSchema) where longSchema.logicalType == .timeMicros:
-            return Double(try decoder.primitive.decode() as Int64) / 1_000_000.0
+            return Double(LogicalTypeConverter.decodeTimeMicros(try decoder.primitive.decode() as Int64).timeIntervalSince1970)
         case .longSchema(let longSchema) where longSchema.logicalType == .timestampMillis:
-            return Double(try decoder.primitive.decode() as Int64) / 1000.0
+            return LogicalTypeConverter.decodeTimestampMillis(try decoder.primitive.decode() as Int64).timeIntervalSince1970
         case .longSchema(let longSchema) where longSchema.logicalType == .timestampMicros:
-            return Double(try decoder.primitive.decode() as Int64) / 1_000_000.0
+            return LogicalTypeConverter.decodeTimestampMicros(try decoder.primitive.decode() as Int64).timeIntervalSince1970
         default:
             throw BinaryDecodingError.typeMismatchWithSchemaDouble
         }
     }
 
     @inlinable func decode<T: Decodable>(_ type: T.Type) throws -> T {
-        try type.init(from: AvroBinaryDecoder(other: decoder, schema: schema))
+        if T.self == Date.self, let date = try decoder.decodeLogicalDate(schema: schema) {
+            return date as! T
+        }
+        return try type.init(from: AvroBinaryDecoder(other: decoder, schema: schema))
     }
 }
 

--- a/Sources/SwiftAvroCore/Codable/AvroDecodable.swift
+++ b/Sources/SwiftAvroCore/Codable/AvroDecodable.swift
@@ -53,6 +53,24 @@ final class AvroDecoder {
         }
     }
 
+    func decode<T: Decodable>(_ type: T.Type, from data: Data, readerSchema: AvroSchema) throws -> T {
+        guard let option = userInfo[infoKey] as? AvroEncodingOption else {
+            throw BinaryEncodingError.noEncoderSpecified
+        }
+        guard option == .AvroBinary else {
+            return try decode(type, from: data)
+        }
+        let resolved = try decodeResolvedValue(from: data, readerSchema: readerSchema)
+        if T.self == Date.self {
+            guard let date = resolved as? Date, let result = date as? T else {
+                throw AvroSchemaResolutionError.SchemaMismatch
+            }
+            return result
+        }
+        let json = try Self.jsonData(from: resolved)
+        return try JSONDecoder().decode(type, from: json)
+    }
+
     func decode<K: Decodable, T: Decodable>(_ type: [K: T].Type, from data: Data) throws -> [K: T] {
         guard !data.isEmpty else { throw BinaryDecodingError.outOfBufferBoundary }
         return try data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
@@ -68,6 +86,41 @@ final class AvroDecoder {
             let pointer = buffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
             let decoder = try AvroBinaryDecoder(schema: schema, pointer: pointer, size: data.count)
             return try decoder.decode(schema: schema)
+        }
+    }
+
+    func decode(from data: Data, readerSchema: AvroSchema) throws -> Any? {
+        try decodeResolvedValue(from: data, readerSchema: readerSchema)
+    }
+
+    private func decodeResolvedValue(from data: Data, readerSchema: AvroSchema) throws -> Any? {
+        let writerValue = try decode(from: data)
+        return try readerSchema.resolveValue(writerValue, writtenBy: schema)
+    }
+
+    private static func jsonData(from value: Any?) throws -> Data {
+        let object = jsonCompatible(value)
+        return try JSONSerialization.data(withJSONObject: object as Any, options: [.fragmentsAllowed])
+    }
+
+    private static func jsonCompatible(_ value: Any?) -> Any {
+        switch value {
+        case nil:
+            return NSNull()
+        case let value as Date:
+            return value.timeIntervalSinceReferenceDate
+        case let value as Decimal:
+            return NSDecimalNumber(decimal: value)
+        case let value as [UInt8]:
+            return value.map { Int($0) }
+        case let value as [Any]:
+            return value.map { jsonCompatible($0) }
+        case let value as [String: Any]:
+            return value.mapValues { jsonCompatible($0) }
+        case let value as Float:
+            return Double(value)
+        default:
+            return value as Any
         }
     }
 }

--- a/Sources/SwiftAvroCore/Codable/AvroEncodable.swift
+++ b/Sources/SwiftAvroCore/Codable/AvroEncodable.swift
@@ -100,11 +100,19 @@ private final class AvroBinaryEncoder: Encoder {
 
     func encode<T: Encodable>(_ value: T) throws {
         switch schema {
-        case .bytesSchema:
-            guard let bytes = value as? [UInt8] else {
-                throw BinaryEncodingError.typeMismatchWithSchema
+        case .bytesSchema(let bytesSchema):
+            if bytesSchema.logicalType == .decimal {
+                guard let decimal = value as? Decimal else {
+                    throw BinaryEncodingError.typeMismatchWithSchema
+                }
+                let encodedBytes = try LogicalTypeConverter.encodeDecimal(decimal, scale: bytesSchema.scale ?? 0, precision: bytesSchema.precision ?? 0)
+                primitive.encode(encodedBytes)
+            } else {
+                guard let bytes = value as? [UInt8] else {
+                    throw BinaryEncodingError.typeMismatchWithSchema
+                }
+                primitive.encode(bytes)
             }
-            primitive.encode(bytes)
 
         case .fixedSchema(let fixed):
             if fixed.logicalType == .duration {
@@ -112,11 +120,42 @@ private final class AvroBinaryEncoder: Encoder {
                     throw BinaryEncodingError.typeMismatchWithSchema
                 }
                 primitive.encode(fixed: values)
+            } else if fixed.logicalType == .decimal {
+                guard let decimal = value as? Decimal else {
+                    throw BinaryEncodingError.typeMismatchWithSchema
+                }
+                let bytes = try LogicalTypeConverter.encodeDecimal(
+                    decimal,
+                    scale: fixed.scale ?? 0,
+                    precision: fixed.precision ?? 0,
+                    fixedSize: fixed.size
+                )
+                primitive.encode(fixed: bytes)
             } else {
                 guard let bytes = value as? [UInt8] else {
                     throw BinaryEncodingError.typeMismatchWithSchema
                 }
                 primitive.encode(fixed: bytes)
+            }
+
+        case .intSchema(let intSchema):
+            if intSchema.logicalType == .date, let date = value as? Date {
+                primitive.encode(LogicalTypeConverter.encodeDate(date))
+            } else if intSchema.logicalType == .timeMillis, let date = value as? Date {
+                primitive.encode(LogicalTypeConverter.encodeTimeMillis(date))
+            } else {
+                try value.encode(to: self)
+            }
+
+        case .longSchema(let longSchema):
+            if longSchema.logicalType == .timestampMillis, let date = value as? Date {
+                primitive.encode(LogicalTypeConverter.encodeTimestampMillis(date))
+            } else if longSchema.logicalType == .timestampMicros, let date = value as? Date {
+                primitive.encode(LogicalTypeConverter.encodeTimestampMicros(date))
+            } else if longSchema.logicalType == .timeMicros, let date = value as? Date {
+                primitive.encode(LogicalTypeConverter.encodeTimeMicros(date))
+            } else {
+                try value.encode(to: self)
             }
 
         case .arraySchema:
@@ -416,11 +455,19 @@ private struct AvroUnkeyedEncodingContainer: UnkeyedEncodingContainer, EncodingH
     mutating func encode<T: Encodable>(_ value: T) throws {
         defer { count += 1 }
         switch schema {
-        case .bytesSchema:
-            guard let bytes = value as? [UInt8] else {
-                throw BinaryEncodingError.typeMismatchWithSchema
+        case .bytesSchema(let bytesSchema):
+            if bytesSchema.logicalType == .decimal {
+                guard let decimal = value as? Decimal else {
+                    throw BinaryEncodingError.typeMismatchWithSchema
+                }
+                let encodedBytes = try LogicalTypeConverter.encodeDecimal(decimal, scale: bytesSchema.scale ?? 0, precision: bytesSchema.precision ?? 0)
+                encoder.primitive.encode(encodedBytes)
+            } else {
+                guard let bytes = value as? [UInt8] else {
+                    throw BinaryEncodingError.typeMismatchWithSchema
+                }
+                encoder.primitive.encode(bytes)
             }
-            encoder.primitive.encode(bytes)
 
         case .fixedSchema(let fixed):
             if fixed.logicalType == .duration {
@@ -428,11 +475,42 @@ private struct AvroUnkeyedEncodingContainer: UnkeyedEncodingContainer, EncodingH
                     throw BinaryEncodingError.typeMismatchWithSchema
                 }
                 encoder.primitive.encode(fixed: values)
+            } else if fixed.logicalType == .decimal {
+                guard let decimal = value as? Decimal else {
+                    throw BinaryEncodingError.typeMismatchWithSchema
+                }
+                let bytes = try LogicalTypeConverter.encodeDecimal(
+                    decimal,
+                    scale: fixed.scale ?? 0,
+                    precision: fixed.precision ?? 0,
+                    fixedSize: fixed.size
+                )
+                encoder.primitive.encode(fixed: bytes)
             } else {
                 guard let bytes = value as? [UInt8] else {
                     throw BinaryEncodingError.typeMismatchWithSchema
                 }
                 encoder.primitive.encode(fixed: bytes)
+            }
+
+        case .intSchema(let intSchema):
+            if intSchema.logicalType == .date, let date = value as? Date {
+                encoder.primitive.encode(LogicalTypeConverter.encodeDate(date))
+            } else if intSchema.logicalType == .timeMillis, let date = value as? Date {
+                encoder.primitive.encode(LogicalTypeConverter.encodeTimeMillis(date))
+            } else {
+                try encoder.encode(value)
+            }
+
+        case .longSchema(let longSchema):
+            if longSchema.logicalType == .timestampMillis, let date = value as? Date {
+                encoder.primitive.encode(LogicalTypeConverter.encodeTimestampMillis(date))
+            } else if longSchema.logicalType == .timestampMicros, let date = value as? Date {
+                encoder.primitive.encode(LogicalTypeConverter.encodeTimestampMicros(date))
+            } else if longSchema.logicalType == .timeMicros, let date = value as? Date {
+                encoder.primitive.encode(LogicalTypeConverter.encodeTimeMicros(date))
+            } else {
+                try encoder.encode(value)
             }
 
         case .arraySchema(let array):
@@ -573,15 +651,15 @@ extension EncodingHelper {
         case .doubleSchema:
             encoder.primitive.encode(value)
         case .intSchema(let param) where param.logicalType == .date:
-            encoder.primitive.encode(Int(value + Date.timeIntervalBetween1970AndReferenceDate))
+            encoder.primitive.encode(LogicalTypeConverter.encodeDate(Date(timeIntervalSince1970: value)))
         case .intSchema(let param) where param.logicalType == .timeMillis:
-            encoder.primitive.encode(Int64(value))
+            encoder.primitive.encode(LogicalTypeConverter.encodeTimeMillis(Date(timeIntervalSince1970: value)))
         case .longSchema(let param) where param.logicalType == .timeMicros:
-            encoder.primitive.encode(Int64(value))
+            encoder.primitive.encode(LogicalTypeConverter.encodeTimeMicros(Date(timeIntervalSince1970: value)))
         case .longSchema(let param) where param.logicalType == .timestampMillis:
-            encoder.primitive.encode(Int64(value))
+            encoder.primitive.encode(LogicalTypeConverter.encodeTimestampMillis(Date(timeIntervalSince1970: value)))
         case .longSchema(let param) where param.logicalType == .timestampMicros:
-            encoder.primitive.encode(Int64(value))
+            encoder.primitive.encode(LogicalTypeConverter.encodeTimestampMicros(Date(timeIntervalSince1970: value)))
         default:
             throw BinaryEncodingError.typeMismatchWithSchemaDouble
         }
@@ -614,4 +692,3 @@ extension EncodingHelper {
     }
 
 }
-

--- a/Sources/SwiftAvroCore/Codable/JSONValue.swift
+++ b/Sources/SwiftAvroCore/Codable/JSONValue.swift
@@ -1,6 +1,6 @@
 /// Native Swift representation of JSON values, replacing Foundation types for OS-independence.
 /// Not Codable directly — encoding is handled by AvroJSONEncoder's container stack.
-public enum JSONValue: Equatable, Sendable {
+public enum JSONValue: Equatable, Codable, Sendable {
     case null
     case bool(Bool)
     case int(Int64)
@@ -8,4 +8,71 @@ public enum JSONValue: Equatable, Sendable {
     case string(String)
     case array([JSONValue])
     case object([String: JSONValue])
+
+    public init(from decoder: Decoder) throws {
+        if var array = try? decoder.unkeyedContainer() {
+            var values: [JSONValue] = []
+            while !array.isAtEnd {
+                values.append(try array.decode(JSONValue.self))
+            }
+            self = .array(values)
+        } else if let object = try? decoder.container(keyedBy: JSONCodingKey.self) {
+            var values: [String: JSONValue] = [:]
+            for key in object.allKeys {
+                values[key.stringValue] = try object.decode(JSONValue.self, forKey: key)
+            }
+            self = .object(values)
+        } else {
+            let single = try decoder.singleValueContainer()
+            if single.decodeNil() {
+                self = .null
+            } else if let value = try? single.decode(Bool.self) {
+                self = .bool(value)
+            } else if let value = try? single.decode(Int64.self) {
+                self = .int(value)
+            } else if let value = try? single.decode(Double.self) {
+                self = .double(value)
+            } else {
+                self = .string(try single.decode(String.self))
+            }
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .array(let values):
+            var container = encoder.unkeyedContainer()
+            for value in values { try container.encode(value) }
+        case .object(let values):
+            var container = encoder.container(keyedBy: JSONCodingKey.self)
+            for (key, value) in values {
+                try container.encode(value, forKey: JSONCodingKey(stringValue: key)!)
+            }
+        default:
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .null:           try container.encodeNil()
+            case .bool(let v):   try container.encode(v)
+            case .int(let v):    try container.encode(v)
+            case .double(let v): try container.encode(v)
+            case .string(let v): try container.encode(v)
+            default: break
+            }
+        }
+    }
+}
+
+private struct JSONCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
 }

--- a/Sources/SwiftAvroCore/Codable/LogicalTypeConverter.swift
+++ b/Sources/SwiftAvroCore/Codable/LogicalTypeConverter.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+/// Internal utility for converting between Avro binary representations and Swift Foundation types.
+internal enum LogicalTypeConverter {
+
+    // MARK: - Date
+
+    static func decodeDate(_ days: Int) -> Date {
+        return Date(timeIntervalSince1970: Double(days) * 86400.0)
+    }
+
+    static func encodeDate(_ date: Date) -> Int {
+        return Int(floor(date.timeIntervalSince1970 / 86400.0))
+    }
+
+    static func decodeTimestampMillis(_ millis: Int64) -> Date {
+        return Date(timeIntervalSince1970: Double(millis) / 1000.0)
+    }
+
+    static func encodeTimestampMillis(_ date: Date) -> Int64 {
+        return Int64(round(date.timeIntervalSince1970 * 1000.0))
+    }
+
+    // MARK: - Decimal
+
+    /// Decodes a decimal from two's complement bytes.
+    static func decodeDecimal(bytes: [UInt8], scale: Int, precision: Int) -> Decimal {
+        guard !bytes.isEmpty else { return 0 }
+        let negative = bytes[0] & 0x80 != 0
+        let magnitude = negative ? twosComplementMagnitude(bytes) : bytes
+        let digits = decimalDigits(fromMagnitudeBytes: magnitude)
+        let decimalString = scaledDecimalString(digits: digits, scale: scale, negative: negative)
+        return Decimal(string: decimalString) ?? 0
+    }
+
+    /// Encodes a decimal to two's complement bytes.
+    static func encodeDecimal(_ decimal: Decimal, scale: Int, precision: Int) throws -> [UInt8] {
+        let (negative, digits) = try unscaledDecimalDigits(decimal, scale: scale, precision: precision)
+        let magnitude = magnitudeBytes(fromDecimalDigits: digits)
+        return negative ? negativeTwosComplementBytes(fromMagnitude: magnitude) : positiveTwosComplementBytes(fromMagnitude: magnitude)
+    }
+
+    static func encodeDecimal(_ decimal: Decimal, scale: Int, precision: Int, fixedSize: Int) throws -> [UInt8] {
+        var bytes = try encodeDecimal(decimal, scale: scale, precision: precision)
+        guard fixedSize >= bytes.count else { throw BinaryEncodingError.invalidDecimal }
+        let pad = bytes.first.map { $0 & 0x80 == 0 ? UInt8(0x00) : UInt8(0xFF) } ?? 0x00
+        if fixedSize > bytes.count {
+            bytes.insert(contentsOf: repeatElement(pad, count: fixedSize - bytes.count), at: 0)
+        }
+        return bytes
+    }
+
+    // MARK: - Timestamp Micros
+
+    static func decodeTimestampMicros(_ micros: Int64) -> Date {
+        return Date(timeIntervalSince1970: Double(micros) / 1_000_000.0)
+    }
+
+    static func encodeTimestampMicros(_ date: Date) -> Int64 {
+        return Int64(round(date.timeIntervalSince1970 * 1_000_000.0))
+    }
+
+    // MARK: - Time Millis
+
+    static func decodeTimeMillis(_ millis: Int32) -> Date {
+        return Date(timeIntervalSince1970: TimeInterval(millis) / 1000.0)
+    }
+
+    static func encodeTimeMillis(_ date: Date) -> Int32 {
+        let secondsInDay: TimeInterval = 86400
+        let timeOfDay = date.timeIntervalSince1970.truncatingRemainder(dividingBy: secondsInDay)
+        let adjusted = timeOfDay < 0 ? timeOfDay + secondsInDay : timeOfDay
+        return Int32(round(adjusted * 1000.0))
+    }
+
+    // MARK: - Time Micros
+
+    static func decodeTimeMicros(_ micros: Int64) -> Date {
+        return Date(timeIntervalSince1970: TimeInterval(micros) / 1_000_000.0)
+    }
+
+    static func encodeTimeMicros(_ date: Date) -> Int64 {
+        let secondsInDay: TimeInterval = 86400
+        let timeOfDay = date.timeIntervalSince1970.truncatingRemainder(dividingBy: secondsInDay)
+        let adjusted = timeOfDay < 0 ? timeOfDay + secondsInDay : timeOfDay
+        return Int64(round(adjusted * 1_000_000.0))
+    }
+
+    // MARK: - Duration
+
+    static func decodeDuration(bytes: [UInt8]) -> [UInt32] {
+        guard bytes.count >= 12 else { return [0, 0, 0] }
+        let months = UInt32(bytes[0]) | UInt32(bytes[1]) << 8 | UInt32(bytes[2]) << 16 | UInt32(bytes[3]) << 24
+        let days   = UInt32(bytes[4]) | UInt32(bytes[5]) << 8 | UInt32(bytes[6]) << 16 | UInt32(bytes[7]) << 24
+        let millis = UInt32(bytes[8]) | UInt32(bytes[9]) << 8 | UInt32(bytes[10]) << 16 | UInt32(bytes[11]) << 24
+        return [months, days, millis]
+    }
+
+    private static func twosComplementMagnitude(_ bytes: [UInt8]) -> [UInt8] {
+        var magnitude = bytes.map { ~$0 }
+        addOne(to: &magnitude)
+        return trimLeadingZeros(magnitude)
+    }
+
+    private static func positiveTwosComplementBytes(fromMagnitude magnitude: [UInt8]) -> [UInt8] {
+        var bytes = trimLeadingZeros(magnitude)
+        if bytes.isEmpty { return [0] }
+        if bytes[0] & 0x80 != 0 { bytes.insert(0, at: 0) }
+        return bytes
+    }
+
+    private static func negativeTwosComplementBytes(fromMagnitude magnitude: [UInt8]) -> [UInt8] {
+        var paddedMagnitude = trimLeadingZeros(magnitude)
+        if paddedMagnitude.isEmpty { return [0] }
+        while true {
+            var bytes = paddedMagnitude.map { ~$0 }
+            addOne(to: &bytes)
+            if bytes[0] & 0x80 != 0 {
+                return trimLeadingSignBytes(bytes)
+            }
+            paddedMagnitude.insert(0, at: 0)
+        }
+    }
+
+    private static func addOne(to bytes: inout [UInt8]) {
+        var carry = 1
+        for i in stride(from: bytes.count - 1, through: 0, by: -1) {
+            let sum = Int(bytes[i]) + carry
+            bytes[i] = UInt8(sum & 0xFF)
+            carry = sum >> 8
+            if carry == 0 { break }
+        }
+        if carry > 0 { bytes.insert(UInt8(carry), at: 0) }
+    }
+
+    private static func decimalDigits(fromMagnitudeBytes bytes: [UInt8]) -> String {
+        var digits = [0]
+        for byte in trimLeadingZeros(bytes) {
+            var carry = Int(byte)
+            for i in stride(from: digits.count - 1, through: 0, by: -1) {
+                let value = digits[i] * 256 + carry
+                digits[i] = value % 10
+                carry = value / 10
+            }
+            while carry > 0 {
+                digits.insert(carry % 10, at: 0)
+                carry /= 10
+            }
+        }
+        return digits.map(String.init).joined()
+    }
+
+    private static func magnitudeBytes(fromDecimalDigits digits: String) -> [UInt8] {
+        var bytes: [UInt8] = [0]
+        for character in digits {
+            guard let digit = character.wholeNumberValue else { continue }
+            var carry = digit
+            for i in stride(from: bytes.count - 1, through: 0, by: -1) {
+                let value = Int(bytes[i]) * 10 + carry
+                bytes[i] = UInt8(value & 0xFF)
+                carry = value >> 8
+            }
+            while carry > 0 {
+                bytes.insert(UInt8(carry & 0xFF), at: 0)
+                carry >>= 8
+            }
+        }
+        return trimLeadingZeros(bytes)
+    }
+
+    private static func scaledDecimalString(digits: String, scale: Int, negative: Bool) -> String {
+        let stripped = stripLeadingZeros(digits)
+        guard stripped != "0" else { return "0" }
+        let unsigned: String
+        if scale == 0 {
+            unsigned = stripped
+        } else if scale >= stripped.count {
+            unsigned = "0." + String(repeating: "0", count: scale - stripped.count) + stripped
+        } else {
+            let point = stripped.index(stripped.endIndex, offsetBy: -scale)
+            unsigned = stripped[..<point] + "." + stripped[point...]
+        }
+        return negative ? "-" + unsigned : unsigned
+    }
+
+    private static func unscaledDecimalDigits(_ decimal: Decimal, scale: Int, precision: Int) throws -> (Bool, String) {
+        var value = decimal
+        var scaled = Decimal()
+        NSDecimalMultiplyByPowerOf10(&scaled, &value, Int16(scale), .plain)
+        var rounded = Decimal()
+        NSDecimalRound(&rounded, &scaled, 0, .plain)
+        var string = NSDecimalNumber(decimal: rounded).stringValue
+        guard string.lowercased() != "nan" else { throw BinaryEncodingError.invalidDecimal }
+        let negative = string.first == "-"
+        if negative { string.removeFirst() }
+        guard string.allSatisfy(\.isNumber) else { throw BinaryEncodingError.invalidDecimal }
+        let digits = stripLeadingZeros(string)
+        if precision > 0, digits.count > precision { throw BinaryEncodingError.invalidDecimal }
+        return (negative && digits != "0", digits)
+    }
+
+    private static func trimLeadingZeros(_ bytes: [UInt8]) -> [UInt8] {
+        let trimmed = bytes.drop { $0 == 0 }
+        return trimmed.isEmpty ? [0] : Array(trimmed)
+    }
+
+    private static func trimLeadingSignBytes(_ bytes: [UInt8]) -> [UInt8] {
+        var bytes = bytes
+        while bytes.count > 1 {
+            let first = bytes[0]
+            let second = bytes[1]
+            if (first == 0x00 && second & 0x80 == 0) || (first == 0xFF && second & 0x80 != 0) {
+                bytes.removeFirst()
+            } else {
+                break
+            }
+        }
+        return bytes
+    }
+
+    private static func stripLeadingZeros(_ string: String) -> String {
+        let stripped = string.drop { $0 == "0" }
+        return stripped.isEmpty ? "0" : String(stripped)
+    }
+}

--- a/Sources/SwiftAvroCore/Schema/AvroSchema+Codable.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema+Codable.swift
@@ -199,13 +199,15 @@ extension AvroSchema {
         case .booleanSchema: try container.encode(Types.boolean)
         case .floatSchema:   try container.encode(Types.float)
         case .doubleSchema:  try container.encode(Types.double)
-        case .stringSchema(_):  try container.encode(Types.string)
+        case .stringSchema(let a):
+            if a.logicalType != nil { try a.encode(to: encoder) }
+            else                    { try container.encode(Types.string) }
         case .intSchema(let a):
-            if let lt = a.logicalType { try container.encode(lt) }
-            else                      { try container.encode(Types.int) }
+            if a.logicalType != nil { try a.encode(to: encoder) }
+            else                    { try container.encode(Types.int) }
         case .longSchema(let a):
-            if let lt = a.logicalType { try container.encode(lt) }
-            else                      { try container.encode(Types.long) }
+            if a.logicalType != nil { try a.encode(to: encoder) }
+            else                    { try container.encode(Types.long) }
         case .bytesSchema(let a):
             if a.logicalType != nil {
                 try a.encode(to: encoder)

--- a/Sources/SwiftAvroCore/Schema/AvroSchema+Codable.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema+Codable.swift
@@ -353,7 +353,7 @@ extension AvroSchema {
         public let  doc:          String?
         public let  order:        String?
         public let  aliases:      [String]?
-        public let  defaultValue: String?
+        public let  defaultValue: JSONValue?
         public let  optional:     Bool?
         var  resolution:   ResolutionMethod = .useDefault
     }
@@ -366,11 +366,13 @@ extension AvroSchema {
         public var type:       String
         public var aliases:    Set<String>?
         public let doc:        String?
+        public var defaultValue: String?
         public var symbols:    [String]
         var resolution: ResolutionMethod = .useDefault
 
-        private enum CodingKeys: CodingKey {
+        private enum CodingKeys: String, CodingKey {
             case name, type, namespace, aliases, symbols, doc
+            case defaultValue = "default"
         }
     }
 
@@ -647,10 +649,13 @@ extension AvroSchema.FieldSchema {
         type = schema
 
         // Present-but-nil means wrong type in JSON; treat as error.
-        order        = try decodeOptionalField(container, key: .order)
-        defaultValue = try decodeOptionalField(container, key: .defaultValue)
-        optional     = try decodeOptionalField(container, key: .optional)
-        doc          = try decodeOptionalField(container, key: .doc)
+        order    = try decodeOptionalField(container, key: .order)
+        optional = try decodeOptionalField(container, key: .optional)
+        doc      = try decodeOptionalField(container, key: .doc)
+        // Use decode (not decodeIfPresent) so JSON null becomes JSONValue.null, not Swift nil.
+        defaultValue = container.contains(.defaultValue)
+            ? try container.decode(JSONValue.self, forKey: .defaultValue)
+            : nil
 
         if container.contains(.aliases) {
             if let single = try? container.decodeIfPresent(String.self, forKey: .aliases) {

--- a/Sources/SwiftAvroCore/Schema/AvroSchema+Evolution.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema+Evolution.swift
@@ -1,0 +1,242 @@
+import Foundation
+
+extension AvroSchema {
+    func resolveValue(_ value: Any?, writtenBy writer: AvroSchema) throws -> Any? {
+        if exactlyMatches(writer) {
+            return value
+        }
+
+        if case .unionSchema(let readerUnion) = self {
+            return try firstMatch(in: readerUnion.branches) { try $0.resolveValue(value, writtenBy: writer) }
+        }
+        if case .unionSchema(let writerUnion) = writer {
+            return try firstMatch(in: writerUnion.branches) { try self.resolveValue(value, writtenBy: $0) }
+        }
+
+        switch (self, writer) {
+        case (.longSchema, .intSchema):
+            return try int64Value(value)
+        case (.floatSchema, .intSchema), (.floatSchema, .longSchema):
+            return Float(try doubleValue(value))
+        case (.doubleSchema, .intSchema), (.doubleSchema, .longSchema), (.doubleSchema, .floatSchema):
+            return try doubleValue(value)
+        case (.bytesSchema, .stringSchema):
+            return Array((try stringValue(value)).utf8)
+        case (.stringSchema, .bytesSchema):
+            guard let bytes = value as? [UInt8],
+                  let string = String(bytes: bytes, encoding: .utf8) else {
+                throw AvroSchemaResolutionError.SchemaMismatch
+            }
+            return string
+        case (.recordSchema(let reader), .recordSchema(let writer)):
+            return try reader.resolveValue(value, writtenBy: writer)
+        case (.errorSchema(let reader), .errorSchema(let writer)):
+            return try reader.resolveValue(value, writtenBy: writer)
+        case (.arraySchema(let reader), .arraySchema(let writer)):
+            guard let values = value as? [Any] else { throw AvroSchemaResolutionError.SchemaMismatch }
+            return try values.map { try reader.items.resolveValue($0, writtenBy: writer.items) as Any }
+        case (.mapSchema(let reader), .mapSchema(let writer)):
+            guard let values = value as? [String: Any] else { throw AvroSchemaResolutionError.SchemaMismatch }
+            return try values.mapValues { try reader.values.resolveValue($0, writtenBy: writer.values) as Any }
+        case (.enumSchema(let reader), .enumSchema(let writer)):
+            guard let symbol = value as? String else { throw AvroSchemaResolutionError.SchemaMismatch }
+            guard writer.symbols.contains(symbol) else { throw AvroSchemaResolutionError.SchemaMismatch }
+            if reader.symbols.contains(symbol) { return symbol }
+            if let defaultValue = reader.defaultValue, reader.symbols.contains(defaultValue) {
+                return defaultValue
+            }
+            throw AvroSchemaResolutionError.SchemaMismatch
+        case (.fixedSchema(let reader), .fixedSchema(let writer)):
+            guard nameMatches(reader, writer), reader.size == writer.size else {
+                throw AvroSchemaResolutionError.SchemaMismatch
+            }
+            return value
+        case (.bytesSchema(let reader), .fixedSchema(let writer))
+            where reader.logicalType == writer.logicalType
+                && reader.precision == writer.precision
+                && reader.scale == writer.scale:
+            return value
+        case (.fixedSchema(let reader), .bytesSchema(let writer))
+            where reader.logicalType == writer.logicalType
+                && reader.precision == writer.precision
+                && reader.scale == writer.scale:
+            return value
+        default:
+            throw AvroSchemaResolutionError.SchemaMismatch
+        }
+    }
+
+    func defaultValue(from json: JSONValue) throws -> Any? {
+        switch self {
+        case .nullSchema:
+            guard json == .null else { throw AvroSchemaResolutionError.SchemaMismatch }
+            return nil
+        case .booleanSchema:
+            guard case .bool(let value) = json else { throw AvroSchemaResolutionError.SchemaMismatch }
+            return value
+        case .intSchema(let schema):
+            let n = try jsonInt(json)
+            switch schema.logicalType {
+            case .date:       return LogicalTypeConverter.decodeDate(Int(n))
+            case .timeMillis: return LogicalTypeConverter.decodeTimeMillis(Int32(n))
+            default:          return Int32(n)
+            }
+        case .longSchema(let schema):
+            let n = try jsonInt(json)
+            switch schema.logicalType {
+            case .timestampMillis:  return LogicalTypeConverter.decodeTimestampMillis(n)
+            case .timestampMicros:  return LogicalTypeConverter.decodeTimestampMicros(n)
+            case .timeMicros:       return LogicalTypeConverter.decodeTimeMicros(n)
+            default:                return n
+            }
+        case .floatSchema:
+            return Float(try jsonDouble(json))
+        case .doubleSchema:
+            return try jsonDouble(json)
+        case .stringSchema:
+            guard case .string(let value) = json else { throw AvroSchemaResolutionError.SchemaMismatch }
+            return value
+        case .bytesSchema:
+            guard case .string(let value) = json else { throw AvroSchemaResolutionError.SchemaMismatch }
+            return Array(value.utf8)
+        case .fixedSchema(let schema):
+            guard case .string(let value) = json else { throw AvroSchemaResolutionError.SchemaMismatch }
+            let bytes = Array(value.utf8)
+            guard bytes.count == schema.size else { throw AvroSchemaResolutionError.SchemaMismatch }
+            return bytes
+        case .enumSchema(let schema):
+            guard case .string(let value) = json, schema.symbols.contains(value) else {
+                throw AvroSchemaResolutionError.SchemaMismatch
+            }
+            return value
+        case .arraySchema(let schema):
+            guard case .array(let values) = json else { throw AvroSchemaResolutionError.SchemaMismatch }
+            return try values.map { try schema.items.defaultValue(from: $0) as Any }
+        case .mapSchema(let schema):
+            guard case .object(let values) = json else { throw AvroSchemaResolutionError.SchemaMismatch }
+            return try values.mapValues { try schema.values.defaultValue(from: $0) as Any }
+        case .recordSchema(let schema), .errorSchema(let schema):
+            guard case .object(let object) = json else { throw AvroSchemaResolutionError.SchemaMismatch }
+            var result: [String: Any] = [:]
+            for field in schema.fields {
+                if let value = object[field.name] {
+                    result[field.name] = try field.type.defaultValue(from: value)
+                } else if let defaultValue = field.defaultValue {
+                    result[field.name] = try field.type.defaultValue(from: defaultValue)
+                } else {
+                    throw AvroSchemaResolutionError.WriterFieldMissingWithoutDefaultValue
+                }
+            }
+            return result
+        case .unionSchema(let schema):
+            guard let branch = schema.branches.first else { throw AvroSchemaResolutionError.SchemaMismatch }
+            return try branch.defaultValue(from: json)
+        default:
+            throw AvroSchemaResolutionError.SchemaMismatch
+        }
+    }
+
+    private func exactlyMatches(_ writer: AvroSchema) -> Bool {
+        switch (self, writer) {
+        case (.nullSchema, .nullSchema),
+             (.booleanSchema, .booleanSchema),
+             (.floatSchema, .floatSchema),
+             (.doubleSchema, .doubleSchema):
+            return true
+        case (.intSchema(let r), .intSchema(let w)):
+            return r == w
+        case (.longSchema(let r), .longSchema(let w)):
+            return r == w
+        case (.bytesSchema(let r), .bytesSchema(let w)):
+            return r == w
+        case (.stringSchema(let r), .stringSchema(let w)):
+            return r == w
+        case (.fixedSchema(let r), .fixedSchema(let w)):
+            return r == w
+        default:
+            return false
+        }
+    }
+}
+
+extension AvroSchema.RecordSchema {
+    fileprivate func resolveValue(_ value: Any?, writtenBy writer: AvroSchema.RecordSchema) throws -> Any? {
+        guard let values = value as? [String: Any] else { throw AvroSchemaResolutionError.SchemaMismatch }
+        var result: [String: Any] = [:]
+        for readerField in fields {
+            if let writerField = writer.field(matching: readerField) {
+                result[readerField.name] = try readerField.type.resolveValue(values[writerField.name], writtenBy: writerField.type)
+            } else if let defaultValue = readerField.defaultValue {
+                result[readerField.name] = try readerField.type.defaultValue(from: defaultValue)
+            } else {
+                throw AvroSchemaResolutionError.WriterFieldMissingWithoutDefaultValue
+            }
+        }
+        return result
+    }
+
+    private func field(matching readerField: AvroSchema.FieldSchema) -> AvroSchema.FieldSchema? {
+        if let field = fields.first(where: { $0.name == readerField.name }) {
+            return field
+        }
+        return fields.first { writerField in
+            readerField.aliases?.contains(writerField.name) == true
+        }
+    }
+}
+
+private func firstMatch(in branches: [AvroSchema], resolve: (AvroSchema) throws -> Any?) throws -> Any? {
+    var lastError: Error = AvroSchemaResolutionError.SchemaMismatch
+    for branch in branches {
+        do { return try resolve(branch) } catch { lastError = error }
+    }
+    throw lastError
+}
+
+private func nameMatches<T: NameSchemaProtocol>(_ reader: T, _ writer: T) -> Bool {
+    if reader.getFullname() == writer.getFullname() { return true }
+    return reader.aliases?.contains(writer.getFullname()) == true
+}
+
+private func int64Value(_ value: Any?) throws -> Int64 {
+    switch value {
+    case let value as Int64: return value
+    case let value as Int32: return Int64(value)
+    case let value as Int: return Int64(value)
+    case let value as Double: return Int64(value)
+    case let value as Float: return Int64(value)
+    default: throw AvroSchemaResolutionError.SchemaMismatch
+    }
+}
+
+private func doubleValue(_ value: Any?) throws -> Double {
+    switch value {
+    case let value as Double: return value
+    case let value as Float: return Double(value)
+    case let value as Int64: return Double(value)
+    case let value as Int32: return Double(value)
+    case let value as Int: return Double(value)
+    default: throw AvroSchemaResolutionError.SchemaMismatch
+    }
+}
+
+private func stringValue(_ value: Any?) throws -> String {
+    guard let value = value as? String else { throw AvroSchemaResolutionError.SchemaMismatch }
+    return value
+}
+
+private func jsonInt(_ value: JSONValue) throws -> Int64 {
+    switch value {
+    case .int(let value): return value
+    case .double(let value): return Int64(value)
+    default: throw AvroSchemaResolutionError.SchemaMismatch
+    }
+}
+
+private func jsonDouble(_ value: JSONValue) throws -> Double {
+    switch value {
+    case .int(let value): return Double(value)
+    case .double(let value): return value
+    default: throw AvroSchemaResolutionError.SchemaMismatch
+    }
+}

--- a/Sources/SwiftAvroCore/Schema/AvroSchema+Reflecting.swift
+++ b/Sources/SwiftAvroCore/Schema/AvroSchema+Reflecting.swift
@@ -23,16 +23,20 @@ extension AvroSchema.RecordSchema {
 
     /// Builds a `RecordSchema` by reflecting the stored properties of `mirror`.
     init(reflecting mirror: Mirror, name: String?) {
-        self.name   = name ?? String(describing: mirror.subjectType)
-        self.type   = AvroSchema.Types.record.rawValue
+        self.name = name ?? String(describing: mirror.subjectType)
+        self.type = AvroSchema.Types.record.rawValue
         self.fields = mirror.children.compactMap { child in
             guard let label = child.label,
-                  let schema = AvroSchema.reflecting(child.value, name: label)
+                let schema = AvroSchema.reflecting(child.value, name: label)
             else { return nil }
             return AvroSchema.FieldSchema(
-                name: label, type: schema,
-                doc: nil, order: nil, aliases: nil,
-                defaultValue: nil, optional: nil
+                name: label,
+                type: schema,
+                doc: nil,
+                order: nil,
+                aliases: nil,
+                defaultValue: nil,
+                optional: nil
             )
         }
         self.doc = nil
@@ -50,18 +54,22 @@ extension AvroSchema {
     static func avroType(for swiftType: Any.Type) -> String? {
         switch ObjectIdentifier(swiftType) {
         case ObjectIdentifier(Int.self),
-             ObjectIdentifier(Int32.self):            return Types.int.rawValue
+            ObjectIdentifier(Int32.self):
+            return Types.int.rawValue
         case ObjectIdentifier(UInt64.self),
-             ObjectIdentifier(Int64.self):            return Types.long.rawValue
+            ObjectIdentifier(Int64.self):
+            return Types.long.rawValue
         case ObjectIdentifier(String.self),
-             ObjectIdentifier(NSString.self):         return Types.string.rawValue
-        case ObjectIdentifier(Double.self):           return Types.double.rawValue
-        case ObjectIdentifier(Float.self):            return Types.float.rawValue
-        case ObjectIdentifier(Bool.self):             return Types.boolean.rawValue
-        case ObjectIdentifier(Date.self):             return Types.int.rawValue   // logical date
+            ObjectIdentifier(NSString.self):
+            return Types.string.rawValue
+        case ObjectIdentifier(Double.self): return Types.double.rawValue
+        case ObjectIdentifier(Float.self): return Types.float.rawValue
+        case ObjectIdentifier(Bool.self): return Types.boolean.rawValue
+        case ObjectIdentifier(Date.self): return Types.long.rawValue  // logical timestamp-millis
         default:
             // [UInt8] has no stable ObjectIdentifier; match by description.
-            return String(describing: swiftType) == "Array<UInt8>" ? Types.bytes.rawValue : nil
+            return String(describing: swiftType) == "Array<UInt8>"
+                ? Types.bytes.rawValue : nil
         }
     }
 
@@ -69,34 +77,47 @@ extension AvroSchema {
 
     /// Reflects `subject` and returns the best-matching `AvroSchema`, or `nil`
     /// if the type cannot be represented.
-    public static func reflecting(_ subject: Any, name: String? = nil) -> AvroSchema? {
+    public static func reflecting(_ subject: Any, name: String? = nil)
+        -> AvroSchema?
+    {
         let mirror = Mirror(reflecting: subject)
 
         if mirror.displayStyle == .optional {
             return reflectOptional(mirror, name: name)
         }
 
-        if let schema = reflectPrimitive(type: mirror.subjectType) { return schema }
+        if let schema = reflectPrimitive(type: mirror.subjectType) {
+            return schema
+        }
 
         switch mirror.displayStyle {
-        case .struct, .class:        return reflectRecord(mirror, name: name)
-        case .enum:                  return reflectEnum(mirror, name: name)
-        case .collection, .set:      return reflectArray(mirror)
-        case .dictionary, .tuple:    return nil   // map reflection is not yet supported
-        case .optional, .none:       return reflectPrimitive(type: mirror.subjectType)
-        default:                     return nil
+        case .struct, .class: return reflectRecord(mirror, name: name)
+        case .enum: return reflectEnum(mirror, name: name)
+        case .collection, .set: return reflectArray(mirror)
+        case .dictionary, .tuple: return nil  // map reflection is not yet supported
+        case .optional, .none: return reflectPrimitive(type: mirror.subjectType)
+        default: return nil
         }
     }
 
     // MARK: Private helpers
 
     private static func reflectPrimitive(type: Any.Type) -> AvroSchema? {
-        if type == Date.self { return .intSchema(IntSchema(type: Types.int.rawValue, logicalType: .date)) }
+        if type == Date.self {
+            return .longSchema(
+                IntSchema(
+                    type: Types.long.rawValue,
+                    logicalType: .timestampMillis
+                )
+            )
+        }
         guard let name = avroType(for: type) else { return nil }
         return AvroSchema(type: name)
     }
 
-    private static func reflectRecord(_ mirror: Mirror, name: String?) -> AvroSchema? {
+    private static func reflectRecord(_ mirror: Mirror, name: String?)
+        -> AvroSchema?
+    {
         .recordSchema(RecordSchema(reflecting: mirror, name: name))
     }
 
@@ -104,7 +125,9 @@ extension AvroSchema {
     ///
     /// Uses `CaseIterable` when available for all case names; falls back to
     /// reflecting the current value only.
-    private static func reflectEnum(_ mirror: Mirror, name: String?) -> AvroSchema? {
+    private static func reflectEnum(_ mirror: Mirror, name: String?)
+        -> AvroSchema?
+    {
         let typeName = String(describing: mirror.subjectType)
         let caseNames: [String]
         if let iterable = mirror.subjectType as? any CaseIterable.Type {
@@ -112,27 +135,40 @@ extension AvroSchema {
                 Mirror(reflecting: $0).children.first?.label ?? "\($0)"
             }
         } else {
-            caseNames = [mirror.children.first?.label ?? "\(mirror.subjectType)"]
+            caseNames = [
+                mirror.children.first?.label ?? "\(mirror.subjectType)"
+            ]
         }
-        return .enumSchema(EnumSchema(
-            name: typeName, type: Types.enums.rawValue, doc: nil, symbols: caseNames
-        ))
+        return .enumSchema(
+            EnumSchema(
+                name: typeName,
+                type: Types.enums.rawValue,
+                doc: nil,
+                symbols: caseNames
+            )
+        )
     }
 
     /// Reflects an array or set by inspecting the first element.
     /// Returns `nil` for empty collections (item type is unknowable via Mirror).
     private static func reflectArray(_ mirror: Mirror) -> AvroSchema? {
         guard let first = mirror.children.first,
-              let itemSchema = reflecting(first.value)
+            let itemSchema = reflecting(first.value)
         else { return nil }
-        return .arraySchema(ArraySchema(type: Types.array.rawValue, items: itemSchema))
+        return .arraySchema(
+            ArraySchema(type: Types.array.rawValue, items: itemSchema)
+        )
     }
 
     /// Handles `Optional<T>`.
     /// - `.some(wrapped)` → union of `[null, innerSchema]`
     /// - `.none`          → `.nullSchema` (inner type not accessible via Mirror)
-    private static func reflectOptional(_ mirror: Mirror, name: String?) -> AvroSchema? {
-        guard let (_, wrapped) = mirror.children.first else { return .nullSchema }
+    private static func reflectOptional(_ mirror: Mirror, name: String?)
+        -> AvroSchema?
+    {
+        guard let (_, wrapped) = mirror.children.first else {
+            return .nullSchema
+        }
         guard let inner = reflecting(wrapped, name: name) else { return nil }
         return .unionSchema(UnionSchema(branches: [.nullSchema, inner]))
     }

--- a/Sources/SwiftAvroCore/SwiftAvroCore.swift
+++ b/Sources/SwiftAvroCore/SwiftAvroCore.swift
@@ -223,11 +223,11 @@ extension Avro {
 
 // MARK: - Options
 
-public enum AvroSchemaEncodingOption: Int {
+public enum AvroSchemaEncodingOption: Int, Sendable {
     case CanonicalForm = 0, FullForm, PrettyPrintedForm
 }
 
-public enum AvroEncodingOption: Int {
+public enum AvroEncodingOption: Int, Sendable {
     case AvroBinary = 0, AvroJson
 }
 

--- a/Sources/SwiftAvroCore/SwiftAvroCore.swift
+++ b/Sources/SwiftAvroCore/SwiftAvroCore.swift
@@ -143,9 +143,27 @@ public class Avro {
         return try AvroDecoder(schema: schema).decode(T.self, from: data)
     }
 
+    /// Decodes a value of type `T` from binary data using separate writer and reader schemas.
+    public func decodeFrom<T: Codable>(
+        from data: Data,
+        writerSchema: AvroSchema,
+        readerSchema: AvroSchema
+    ) throws -> T {
+        return try AvroDecoder(schema: writerSchema).decode(T.self, from: data, readerSchema: readerSchema)
+    }
+
     /// Decodes an untyped value from binary data using the provided schema.
     public func decodeFrom(from data: Data, schema: AvroSchema) throws -> Any? {
         return try AvroDecoder(schema: schema).decode(from: data)
+    }
+
+    /// Decodes an untyped value from binary data using separate writer and reader schemas.
+    public func decodeFrom(
+        from data: Data,
+        writerSchema: AvroSchema,
+        readerSchema: AvroSchema
+    ) throws -> Any? {
+        return try AvroDecoder(schema: writerSchema).decode(from: data, readerSchema: readerSchema)
     }
 
     // MARK: - Streaming decode

--- a/Tests/SwiftAvroCoreTests/AvroDecodableTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroDecodableTest.swift
@@ -49,7 +49,7 @@ struct AvroDecodableTests {
             0x01,                                        // bool: true
             0x96, 0xde, 0x87, 0x03,                     // int: 3209099
             0x96, 0xde, 0x87, 0x03,                     // long: 3209099
-            0xA0, 0x38,                                 // date: 3600 seconds
+            0x00,                                       // date: 0 days (Unix epoch)
             0xc3, 0xf5, 0x48, 0x40,                     // float: 3.14
             0x1f, 0x85, 0xeb, 0x51, 0xb8, 0x1e, 0x09, 0x40, // double: 3.14
             0x06, 0x66, 0x6f, 0x6f,                     // string: "foo"
@@ -67,7 +67,7 @@ struct AvroDecodableTests {
         #expect(value.boolField == true)
         #expect(value.intField == 3209099)
         #expect(value.longField == 3209099)
-        #expect(value.dateField == Date(timeIntervalSince1970: 3600))
+        #expect(value.dateField == Date(timeIntervalSince1970: 0))
         #expect(abs(value.floatField - 3.14) < 0.001)
         #expect(abs(value.doubleField - 3.14) < 0.0001)
         #expect(value.stringField == "foo")
@@ -79,6 +79,7 @@ struct AvroDecodableTests {
         let anyValue = try decoder.decode(from: data) as! [String: Any]
         #expect(anyValue["boolField"] as! Bool == true)
         #expect(anyValue["intField"] as! Int32 == 3209099)
+        #expect((anyValue["dateField"] as? Date)?.timeIntervalSince1970 == 0)
     }
 
     // MARK: - Complex types

--- a/Tests/SwiftAvroCoreTests/AvroDecodableTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroDecodableTest.swift
@@ -1147,6 +1147,264 @@ struct EmptyDataErrorTests {
     }
 }
 
+@Suite("Avro schema evolution decoding")
+struct AvroSchemaEvolutionDecodingTests {
+    let avro = Avro()
+
+    @Test("reader reorders fields and skips writer-only fields")
+    func reorderAndSkipWriterFields() throws {
+        struct Reader: Codable, Equatable {
+            let b: String
+            let a: Int32
+        }
+
+        struct Writer: Codable {
+            let a: Int32
+            let ignored: Int32
+            let b: String
+        }
+
+        let writerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[
+          {"name":"a","type":"int"},
+          {"name":"ignored","type":"int"},
+          {"name":"b","type":"string"}]}
+        """#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[
+          {"name":"b","type":"string"},
+          {"name":"a","type":"int"}]}
+        """#))
+
+        let data = try avro.encodeFrom(Writer(a: 7, ignored: 99, b: "bee"), schema: writerSchema)
+        let decoded: Reader = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema)
+        #expect(decoded == Reader(b: "bee", a: 7))
+    }
+
+    @Test("reader adds fields from defaults")
+    func readerFieldDefaults() throws {
+        struct Writer: Codable {
+            let a: Int32
+        }
+
+        struct Reader: Codable, Equatable {
+            let a: Int32
+            let b: String
+            let c: Bool
+        }
+
+        let writerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[{"name":"a","type":"int"}]}
+        """#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[
+          {"name":"a","type":"int"},
+          {"name":"b","type":"string","default":"defaulted"},
+          {"name":"c","type":"boolean","default":true}]}
+        """#))
+
+        let data = try avro.encodeFrom(Writer(a: 42), schema: writerSchema)
+        let decoded: Reader = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema)
+        #expect(decoded == Reader(a: 42, b: "defaulted", c: true))
+    }
+
+    @Test("reader field aliases match writer field names")
+    func fieldAliases() throws {
+        struct Writer: Codable {
+            let oldName: Int32
+        }
+
+        struct Reader: Codable, Equatable {
+            let newName: Int32
+        }
+
+        let writerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[{"name":"oldName","type":"int"}]}
+        """#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[{"name":"newName","type":"int","aliases":["oldName"]}]}
+        """#))
+
+        let data = try avro.encodeFrom(Writer(oldName: 11), schema: writerSchema)
+        let decoded: Reader = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema)
+        #expect(decoded == Reader(newName: 11))
+    }
+
+    @Test("nested array item promotion")
+    func nestedArrayPromotion() throws {
+        let writerSchema = try #require(avro.decodeSchema(schema: #"{"type":"array","items":"int"}"#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"{"type":"array","items":"long"}"#))
+        let data = try avro.encodeFrom([Int32(1), Int32(2), Int32(3)], schema: writerSchema)
+        let decoded: [Int64] = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema)
+        #expect(decoded == [1, 2, 3])
+    }
+
+    @Test("enum reader default handles unknown writer symbol")
+    func enumDefault() throws {
+        let writerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"enum","name":"E","symbols":["A","B","C"]}
+        """#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"enum","name":"E","symbols":["A","B"],"default":"A"}
+        """#))
+        let data = try avro.encodeFrom("C", schema: writerSchema)
+        let decoded: String = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema)
+        #expect(decoded == "A")
+    }
+
+    @Test("untyped schema evolution decode returns reader shape")
+    func untypedReaderShape() throws {
+        struct Writer: Codable {
+            let a: Int32
+        }
+
+        let writerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[{"name":"a","type":"int"}]}
+        """#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[
+          {"name":"renamed","type":"long","aliases":["a"]},
+          {"name":"extra","type":"string","default":"x"}]}
+        """#))
+        let data = try avro.encodeFrom(Writer(a: 5), schema: writerSchema)
+        let decoded = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema) as? [String: Any]
+        #expect(decoded?["renamed"] as? Int64 == 5)
+        #expect(decoded?["extra"] as? String == "x")
+    }
+
+    @Test("null union default fills missing reader field")
+    func nullUnionDefault() throws {
+        struct Writer: Codable {
+            let a: Int32
+        }
+
+        struct Reader: Codable, Equatable {
+            let a: Int32
+            let b: String?
+        }
+
+        let writerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[{"name":"a","type":"int"}]}
+        """#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[
+          {"name":"a","type":"int"},
+          {"name":"b","type":["null","string"],"default":null}]}
+        """#))
+
+        let data = try avro.encodeFrom(Writer(a: 3), schema: writerSchema)
+        let decoded: Reader = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema)
+        #expect(decoded == Reader(a: 3, b: nil))
+    }
+
+    @Test("byte array default value round-trips through evolution")
+    func byteArrayFieldEvolution() throws {
+        struct Writer: Codable {
+            let a: Int32
+        }
+
+        struct Reader: Codable, Equatable {
+            let a: Int32
+            let payload: [Int]
+        }
+
+        let writerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[{"name":"a","type":"int"}]}
+        """#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[
+          {"name":"a","type":"int"},
+          {"name":"payload","type":"bytes","default":"\u0001\u0002\u0003"}]}
+        """#))
+
+        let data = try avro.encodeFrom(Writer(a: 9), schema: writerSchema)
+        let decoded: Reader = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema)
+        #expect(decoded == Reader(a: 9, payload: [1, 2, 3]))
+    }
+
+    @Test("nested record default fills missing reader field")
+    func nestedRecordDefault() throws {
+        struct Writer: Codable {
+            let id: Int32
+        }
+
+        struct Inner: Codable, Equatable {
+            let x: Int32
+            let y: Int32
+        }
+
+        struct Reader: Codable, Equatable {
+            let id: Int32
+            let point: Inner
+        }
+
+        let writerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[{"name":"id","type":"int"}]}
+        """#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[
+          {"name":"id","type":"int"},
+          {"name":"point","type":{"type":"record","name":"Inner","fields":[
+            {"name":"x","type":"int"},
+            {"name":"y","type":"int"}
+          ]},"default":{"x":10,"y":20}}]}
+        """#))
+
+        let data = try avro.encodeFrom(Writer(id: 7), schema: writerSchema)
+        let decoded: Reader = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema)
+        #expect(decoded == Reader(id: 7, point: Inner(x: 10, y: 20)))
+    }
+
+    @Test("writer null value propagates instead of using reader default")
+    func writerNullOverridesDefault() throws {
+        struct Writer: Codable {
+            let a: Int32
+            let b: String?
+        }
+
+        struct Reader: Codable, Equatable {
+            let a: Int32
+            let b: String?
+        }
+
+        let writerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[
+          {"name":"a","type":"int"},
+          {"name":"b","type":["null","string"]}]}
+        """#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[
+          {"name":"a","type":"int"},
+          {"name":"b","type":["null","string"],"default":null}]}
+        """#))
+
+        let data = try avro.encodeFrom(Writer(a: 5, b: nil), schema: writerSchema)
+        let decoded: Reader = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema)
+        #expect(decoded == Reader(a: 5, b: nil))
+    }
+
+    @Test("missing reader field without default throws")
+    func missingFieldWithoutDefault() throws {
+        struct Writer: Codable {
+            let a: Int32
+        }
+
+        let writerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[{"name":"a","type":"int"}]}
+        """#))
+        let readerSchema = try #require(avro.decodeSchema(schema: #"""
+        {"type":"record","name":"R","fields":[
+          {"name":"a","type":"int"},
+          {"name":"b","type":"string"}]}
+        """#))
+
+        let data = try avro.encodeFrom(Writer(a: 1), schema: writerSchema)
+        #expect(throws: AvroSchemaResolutionError.WriterFieldMissingWithoutDefaultValue) {
+            let _: Any? = try avro.decodeFrom(from: data, writerSchema: writerSchema, readerSchema: readerSchema)
+        }
+    }
+}
+
 private struct TestKey: CodingKey {
     var stringValue: String
     var intValue: Int?

--- a/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroSchemaCodingTest.swift
@@ -279,7 +279,7 @@ struct AvroSchemaCodingTests {
         let valueList = r.fields[4].type.getUnionList()
         #expect(valueList.count == 11)
         #expect(valueList[5].getName() == "innerRecord")
-        #expect(valueList[5].getRecord()?.fields[0].defaultValue == "default_value")
+        #expect(valueList[5].getRecord()?.fields[0].defaultValue == .string("default_value"))
         #expect(valueList[9].isEnum())
         #expect(valueList[9].getEnumSymbols() == ["SPADES","HEARTS","DIAMONDS","CLUBS"])
     }

--- a/Tests/SwiftAvroCoreTests/AvroSchemaReflectingTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroSchemaReflectingTest.swift
@@ -41,9 +41,9 @@ struct AvroSchemaReflectingTests {
         #expect(AvroSchema.avroType(for: Bool.self) == "boolean")
     }
 
-    @Test("avroType returns int for Date (logical date)")
+    @Test("avroType returns long for Date (logical timestamp-millis)")
     func avroTypeDate() {
-        #expect(AvroSchema.avroType(for: Date.self) == "int")
+        #expect(AvroSchema.avroType(for: Date.self) == "long")
     }
 
     @Test("avroType returns bytes for Array<UInt8>")
@@ -107,10 +107,10 @@ struct AvroSchemaReflectingTests {
         #expect(schema?.isBoolean() == true)
     }
 
-    @Test("reflecting returns date schema for Date")
+    @Test("reflecting returns long schema for Date")
     func reflectingDate() {
         let schema = AvroSchema.reflecting(Date())
-        #expect(schema?.isInt() == true)
+        #expect(schema?.isLong() == true)
     }
 
     @Test("reflecting returns bytes schema for [UInt8]")
@@ -192,6 +192,59 @@ struct AvroSchemaReflectingTests {
         struct Point { var x: Double = 0; var y: Double = 0 }
         let schema = AvroSchema.reflecting(Point(), name: "CustomPoint")
         #expect(schema?.getName() == "CustomPoint")
+    }
+
+    @Test("reflecting builds schema for nested Codable action")
+    func reflectingNestedCodableAction() throws {
+        struct Kitty: Codable, Equatable {
+            enum KittyColor: String, Codable, CaseIterable {
+                case Brown, White, Black
+            }
+
+            let name: String
+            let color: KittyColor
+        }
+
+        struct KittyAction: Codable, Equatable {
+            enum KittyActionType: String, Codable, CaseIterable {
+                case meow, jump, bite
+            }
+
+            let label: String
+            let type: KittyActionType
+            let timestamp: Date
+            let dataValue: [UInt8]
+            let intValue: Int
+            let floatValue: Float
+            let doubleValue: Double
+            let kitty: Kitty
+        }
+
+        let action = KittyAction(
+            label: "test",
+            type: .meow,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            dataValue: [1],
+            intValue: 1,
+            floatValue: 1.0,
+            doubleValue: 1.0,
+            kitty: Kitty(name: "test", color: .Brown)
+        )
+
+        let schema = try #require(AvroSchema.reflecting(action))
+        let record = try #require(schema.getRecord())
+        let fields = Dictionary(uniqueKeysWithValues: record.fields.map { ($0.name, $0.type) })
+
+        #expect(record.name == "KittyAction")
+        #expect(fields["label"]?.isString() == true)
+        #expect(fields["type"]?.isEnum() == true)
+        #expect(fields["timestamp"]?.isLong() == true)
+        #expect(fields["timestamp"]?.getName() == "timestamp-millis")
+        #expect(fields["dataValue"]?.isBytes() == true)
+        #expect(fields["intValue"]?.isInt() == true)
+        #expect(fields["floatValue"]?.isFloat() == true)
+        #expect(fields["doubleValue"]?.isDouble() == true)
+        #expect(fields["kitty"]?.isRecord() == true)
     }
 
     @Test("reflecting returns enum schema for non-CaseIterable enum")

--- a/Tests/SwiftAvroCoreTests/CoverageTargetTests.swift
+++ b/Tests/SwiftAvroCoreTests/CoverageTargetTests.swift
@@ -1,0 +1,813 @@
+import Testing
+import Foundation
+@testable import SwiftAvroCore
+
+// MARK: - Helpers
+
+private func parse(_ json: String) throws -> AvroSchema {
+    let avro = Avro()
+    return try #require(avro.decodeSchema(schema: json))
+}
+
+// MARK: - JSONValue Tests
+
+@Suite("JSONValue – Codable")
+struct JSONValueCodableTests {
+
+    @Test func nullRoundTrip() throws {
+        let data = try JSONEncoder().encode(JSONValue.null)
+        #expect(try JSONDecoder().decode(JSONValue.self, from: data) == .null)
+    }
+
+    @Test func boolTrueRoundTrip() throws {
+        let data = try JSONEncoder().encode(JSONValue.bool(true))
+        #expect(try JSONDecoder().decode(JSONValue.self, from: data) == .bool(true))
+    }
+
+    @Test func boolFalseRoundTrip() throws {
+        let data = try JSONEncoder().encode(JSONValue.bool(false))
+        #expect(try JSONDecoder().decode(JSONValue.self, from: data) == .bool(false))
+    }
+
+    @Test func intRoundTrip() throws {
+        let data = try JSONEncoder().encode(JSONValue.int(9999))
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+        switch decoded {
+        case .int(let v): #expect(v == 9999)
+        case .double(let v): #expect(Int64(v) == 9999)
+        default: Issue.record("unexpected case")
+        }
+    }
+
+    @Test func doubleRoundTrip() throws {
+        let data = try JSONEncoder().encode(JSONValue.double(1.5))
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+        if case .double(let v) = decoded { #expect(v == 1.5) }
+        else { Issue.record("expected .double") }
+    }
+
+    @Test func stringRoundTrip() throws {
+        let data = try JSONEncoder().encode(JSONValue.string("avro"))
+        #expect(try JSONDecoder().decode(JSONValue.self, from: data) == .string("avro"))
+    }
+
+    @Test func arrayRoundTrip() throws {
+        let val = JSONValue.array([.null, .bool(true), .int(1), .double(2.5), .string("s")])
+        let data = try JSONEncoder().encode(val)
+        #expect(try JSONDecoder().decode(JSONValue.self, from: data) == val)
+    }
+
+    @Test func objectRoundTrip() throws {
+        let val = JSONValue.object(["a": .int(1), "b": .string("x")])
+        let data = try JSONEncoder().encode(val)
+        #expect(try JSONDecoder().decode(JSONValue.self, from: data) == val)
+    }
+
+    @Test func nestedRoundTrip() throws {
+        let val = JSONValue.object(["arr": .array([.int(1)]), "obj": .object(["x": .null])])
+        let data = try JSONEncoder().encode(val)
+        #expect(try JSONDecoder().decode(JSONValue.self, from: data) == val)
+    }
+
+    @Test func decodeRawNull() throws {
+        #expect(try JSONDecoder().decode(JSONValue.self, from: Data("null".utf8)) == .null)
+    }
+
+    @Test func decodeRawBool() throws {
+        #expect(try JSONDecoder().decode(JSONValue.self, from: Data("true".utf8)) == .bool(true))
+    }
+
+    @Test func decodeRawString() throws {
+        #expect(try JSONDecoder().decode(JSONValue.self, from: Data(#""hello""#.utf8)) == .string("hello"))
+    }
+
+    @Test func decodeRawDouble() throws {
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: Data("3.14".utf8))
+        if case .double(let v) = decoded { #expect(abs(v - 3.14) < 0.001) }
+        else { Issue.record("expected .double") }
+    }
+}
+
+// MARK: - LogicalTypeConverter Tests
+
+@Suite("LogicalTypeConverter")
+struct LogicalTypeConverterTests {
+
+    @Test func decodeDateZero() {
+        #expect(LogicalTypeConverter.decodeDate(0).timeIntervalSince1970 == 0)
+    }
+
+    @Test func decodeDateOneDay() {
+        #expect(LogicalTypeConverter.decodeDate(1).timeIntervalSince1970 == 86400)
+    }
+
+    @Test func encodeDateFloors() {
+        let date = Date(timeIntervalSince1970: 86400 * 1.7)
+        #expect(LogicalTypeConverter.encodeDate(date) == 1)
+    }
+
+    @Test func encodeDateRoundTrip() {
+        let date = Date(timeIntervalSince1970: 86400 * 100)
+        #expect(LogicalTypeConverter.decodeDate(LogicalTypeConverter.encodeDate(date)) == date)
+    }
+
+    @Test func timestampMillisRoundTrip() {
+        let millis: Int64 = 1_622_548_800_123
+        let date = LogicalTypeConverter.decodeTimestampMillis(millis)
+        #expect(LogicalTypeConverter.encodeTimestampMillis(date) == millis)
+    }
+
+    @Test func timestampMicrosRoundTrip() {
+        let micros: Int64 = 1_622_548_800_123_456
+        let date = LogicalTypeConverter.decodeTimestampMicros(micros)
+        #expect(abs(LogicalTypeConverter.encodeTimestampMicros(date) - micros) <= 1)
+    }
+
+    @Test func decodeTimestampMicrosZero() {
+        #expect(LogicalTypeConverter.decodeTimestampMicros(0).timeIntervalSince1970 == 0)
+    }
+
+    @Test func timeMillisNoon() {
+        let date = Date(timeIntervalSince1970: 12 * 3600)
+        #expect(LogicalTypeConverter.encodeTimeMillis(date) == 12 * 3600 * 1000)
+    }
+
+    @Test func timeMillisNegativeAdjusted() {
+        // -1 second from epoch → time-of-day = 86399s
+        let date = Date(timeIntervalSince1970: -1)
+        #expect(LogicalTypeConverter.encodeTimeMillis(date) == 86_399_000)
+    }
+
+    @Test func timeMicrosRoundTrip() {
+        let micros: Int64 = 43_200_000_000
+        let date = LogicalTypeConverter.decodeTimeMicros(micros)
+        #expect(abs(LogicalTypeConverter.encodeTimeMicros(date) - micros) <= 1)
+    }
+
+    @Test func timeMicrosNegativeAdjusted() {
+        let date = Date(timeIntervalSince1970: -1)
+        #expect(LogicalTypeConverter.encodeTimeMicros(date) == 86_399_000_000)
+    }
+
+    @Test func decodeDurationShortBytes() {
+        #expect(LogicalTypeConverter.decodeDuration(bytes: [1, 2]) == [0, 0, 0])
+    }
+
+    @Test func decodeDurationExactly12Bytes() {
+        var b = [UInt8](repeating: 0, count: 12)
+        b[0] = 1; b[4] = 2; b[8] = 3
+        #expect(LogicalTypeConverter.decodeDuration(bytes: b) == [1, 2, 3])
+    }
+
+    @Test func decodeDurationMultiByte() {
+        var b = [UInt8](repeating: 0, count: 12)
+        b[0] = 0x00; b[1] = 0x01  // months = 256
+        let result = LogicalTypeConverter.decodeDuration(bytes: b)
+        #expect(result[0] == 256)
+    }
+
+    @Test func decodeDecimalEmptyBytes() {
+        #expect(LogicalTypeConverter.decodeDecimal(bytes: [], scale: 2, precision: 10) == 0)
+    }
+
+    @Test func decimalPositiveRoundTrip() throws {
+        let d = Decimal(string: "123.45")!
+        let bytes = try LogicalTypeConverter.encodeDecimal(d, scale: 2, precision: 10)
+        #expect(LogicalTypeConverter.decodeDecimal(bytes: bytes, scale: 2, precision: 10) == d)
+    }
+
+    @Test func decimalNegativeRoundTrip() throws {
+        let d = Decimal(string: "-123.45")!
+        let bytes = try LogicalTypeConverter.encodeDecimal(d, scale: 2, precision: 10)
+        #expect(LogicalTypeConverter.decodeDecimal(bytes: bytes, scale: 2, precision: 10) == d)
+    }
+
+    @Test func decimalZeroRoundTrip() throws {
+        let bytes = try LogicalTypeConverter.encodeDecimal(.zero, scale: 2, precision: 10)
+        #expect(LogicalTypeConverter.decodeDecimal(bytes: bytes, scale: 2, precision: 10) == 0)
+    }
+
+    @Test func decimalScaleZeroRoundTrip() throws {
+        let d = Decimal(42)
+        let bytes = try LogicalTypeConverter.encodeDecimal(d, scale: 0, precision: 10)
+        #expect(LogicalTypeConverter.decodeDecimal(bytes: bytes, scale: 0, precision: 10) == d)
+    }
+
+    @Test func decimalScaleGreaterThanDigits() throws {
+        let d = Decimal(string: "0.00123")!
+        let bytes = try LogicalTypeConverter.encodeDecimal(d, scale: 5, precision: 10)
+        #expect(LogicalTypeConverter.decodeDecimal(bytes: bytes, scale: 5, precision: 10) == d)
+    }
+
+    @Test func decimalLargeValue() throws {
+        let d = Decimal(string: "12345678901234567890.12")!
+        let bytes = try LogicalTypeConverter.encodeDecimal(d, scale: 2, precision: 24)
+        #expect(LogicalTypeConverter.decodeDecimal(bytes: bytes, scale: 2, precision: 24) == d)
+    }
+
+    @Test func decimalNegativeSmall() throws {
+        let d = Decimal(string: "-0.01")!
+        let bytes = try LogicalTypeConverter.encodeDecimal(d, scale: 2, precision: 10)
+        #expect(LogicalTypeConverter.decodeDecimal(bytes: bytes, scale: 2, precision: 10) == d)
+    }
+
+    @Test func decimalPrecisionExceededThrows() {
+        #expect(throws: BinaryEncodingError.invalidDecimal) {
+            try LogicalTypeConverter.encodeDecimal(Decimal(string: "123456789012")!, scale: 0, precision: 5)
+        }
+    }
+
+    @Test func decimalFixedSizeTooSmallThrows() {
+        #expect(throws: BinaryEncodingError.invalidDecimal) {
+            try LogicalTypeConverter.encodeDecimal(Decimal(string: "1234567890")!, scale: 0, precision: 15, fixedSize: 1)
+        }
+    }
+
+    @Test func decimalFixedSizePadsPositive() throws {
+        let bytes = try LogicalTypeConverter.encodeDecimal(Decimal(string: "1.23")!, scale: 2, precision: 10, fixedSize: 4)
+        #expect(bytes.count == 4)
+        #expect(bytes[0] == 0x00)
+    }
+
+    @Test func decimalFixedSizePadsNegative() throws {
+        let bytes = try LogicalTypeConverter.encodeDecimal(Decimal(string: "-1.23")!, scale: 2, precision: 10, fixedSize: 4)
+        #expect(bytes.count == 4)
+        #expect(bytes[0] == 0xFF)
+    }
+
+    @Test func decimalNegativeFromBytes() throws {
+        // [0xFF] = -1 in two's complement, scale=2 → -0.01
+        let result = LogicalTypeConverter.decodeDecimal(bytes: [0xFF], scale: 2, precision: 10)
+        #expect(result == Decimal(string: "-0.01")!)
+    }
+}
+
+// MARK: - AvroSchema+Evolution: resolveValue
+
+@Suite("AvroSchema+Evolution – resolveValue")
+struct EvolutionResolveValueTests {
+
+    // MARK: exactlyMatches → early return
+
+    @Test func resolveNullExact() throws {
+        let s = try parse(#""null""#)
+        #expect(try s.resolveValue(nil, writtenBy: s) == nil)
+    }
+
+    @Test func resolveBoolExact() throws {
+        let s = try parse(#""boolean""#)
+        #expect(try s.resolveValue(true, writtenBy: s) as? Bool == true)
+    }
+
+    @Test func resolveFloatExact() throws {
+        let s = try parse(#""float""#)
+        #expect(try s.resolveValue(Float(1.5), writtenBy: s) as? Float == 1.5)
+    }
+
+    @Test func resolveDoubleExact() throws {
+        let s = try parse(#""double""#)
+        #expect(try s.resolveValue(Double(2.5), writtenBy: s) as? Double == 2.5)
+    }
+
+    @Test func resolveIntExact() throws {
+        let s = try parse(#"{"type":"int"}"#)
+        #expect(try s.resolveValue(Int32(7), writtenBy: s) as? Int32 == 7)
+    }
+
+    @Test func resolveLongExact() throws {
+        let s = try parse(#"{"type":"long"}"#)
+        #expect(try s.resolveValue(Int64(8), writtenBy: s) as? Int64 == 8)
+    }
+
+    @Test func resolveBytesExact() throws {
+        let s = try parse(#"{"type":"bytes"}"#)
+        let b: [UInt8] = [1, 2]
+        #expect(try s.resolveValue(b, writtenBy: s) as? [UInt8] == b)
+    }
+
+    @Test func resolveStringExact() throws {
+        let s = try parse(#"{"type":"string"}"#)
+        #expect(try s.resolveValue("hi", writtenBy: s) as? String == "hi")
+    }
+
+    // MARK: int64Value all branches
+
+    @Test func longFromInt64() throws {
+        let r = try parse(#"{"type":"long"}"#); let w = try parse(#"{"type":"int"}"#)
+        #expect(try r.resolveValue(Int64(1), writtenBy: w) as? Int64 == 1)
+    }
+
+    @Test func longFromInt32() throws {
+        let r = try parse(#"{"type":"long"}"#); let w = try parse(#"{"type":"int"}"#)
+        #expect(try r.resolveValue(Int32(2), writtenBy: w) as? Int64 == 2)
+    }
+
+    @Test func longFromInt() throws {
+        let r = try parse(#"{"type":"long"}"#); let w = try parse(#"{"type":"int"}"#)
+        #expect(try r.resolveValue(Int(3), writtenBy: w) as? Int64 == 3)
+    }
+
+    @Test func longFromDouble() throws {
+        let r = try parse(#"{"type":"long"}"#); let w = try parse(#"{"type":"int"}"#)
+        #expect(try r.resolveValue(Double(4), writtenBy: w) as? Int64 == 4)
+    }
+
+    @Test func longFromFloat() throws {
+        let r = try parse(#"{"type":"long"}"#); let w = try parse(#"{"type":"int"}"#)
+        #expect(try r.resolveValue(Float(5), writtenBy: w) as? Int64 == 5)
+    }
+
+    @Test func longFromInvalidThrows() throws {
+        let r = try parse(#"{"type":"long"}"#); let w = try parse(#"{"type":"int"}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue("bad", writtenBy: w)
+        }
+    }
+
+    // MARK: doubleValue all branches
+
+    @Test func doubleFromDouble() throws {
+        let r = try parse(#"{"type":"double"}"#); let w = try parse(#"{"type":"float"}"#)
+        #expect(try r.resolveValue(Double(1.0), writtenBy: w) as? Double == 1.0)
+    }
+
+    @Test func doubleFromFloat() throws {
+        let r = try parse(#"{"type":"double"}"#); let w = try parse(#"{"type":"float"}"#)
+        #expect(try r.resolveValue(Float(2.0), writtenBy: w) as? Double == 2.0)
+    }
+
+    @Test func doubleFromInt64() throws {
+        let r = try parse(#"{"type":"double"}"#); let w = try parse(#"{"type":"long"}"#)
+        #expect(try r.resolveValue(Int64(3), writtenBy: w) as? Double == 3.0)
+    }
+
+    @Test func doubleFromInt32() throws {
+        let r = try parse(#"{"type":"double"}"#); let w = try parse(#"{"type":"int"}"#)
+        #expect(try r.resolveValue(Int32(4), writtenBy: w) as? Double == 4.0)
+    }
+
+    @Test func doubleFromInt() throws {
+        let r = try parse(#"{"type":"double"}"#); let w = try parse(#"{"type":"int"}"#)
+        #expect(try r.resolveValue(Int(5), writtenBy: w) as? Double == 5.0)
+    }
+
+    @Test func doubleFromInvalidThrows() throws {
+        let r = try parse(#"{"type":"double"}"#); let w = try parse(#"{"type":"float"}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue("bad", writtenBy: w)
+        }
+    }
+
+    // MARK: float promotions
+
+    @Test func floatFromInt() throws {
+        let r = try parse(#"{"type":"float"}"#); let w = try parse(#"{"type":"int"}"#)
+        #expect(try r.resolveValue(Int32(5), writtenBy: w) as? Float == 5.0)
+    }
+
+    @Test func floatFromLong() throws {
+        let r = try parse(#"{"type":"float"}"#); let w = try parse(#"{"type":"long"}"#)
+        #expect(try r.resolveValue(Int64(6), writtenBy: w) as? Float == 6.0)
+    }
+
+    // MARK: bytes ↔ string
+
+    @Test func bytesFromString() throws {
+        let r = try parse(#"{"type":"bytes"}"#); let w = try parse(#"{"type":"string"}"#)
+        #expect(try r.resolveValue("hi", writtenBy: w) as? [UInt8] == Array("hi".utf8))
+    }
+
+    @Test func bytesFromStringInvalidTypeThrows() throws {
+        let r = try parse(#"{"type":"bytes"}"#); let w = try parse(#"{"type":"string"}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue(42, writtenBy: w)
+        }
+    }
+
+    @Test func stringFromBytes() throws {
+        let r = try parse(#"{"type":"string"}"#); let w = try parse(#"{"type":"bytes"}"#)
+        #expect(try r.resolveValue(Array("hi".utf8), writtenBy: w) as? String == "hi")
+    }
+
+    @Test func stringFromBytesInvalidUTF8Throws() throws {
+        let r = try parse(#"{"type":"string"}"#); let w = try parse(#"{"type":"bytes"}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue([UInt8]([0xFF, 0xFE]), writtenBy: w)
+        }
+    }
+
+    @Test func stringFromBytesNonArrayThrows() throws {
+        let r = try parse(#"{"type":"string"}"#); let w = try parse(#"{"type":"bytes"}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue("notBytes", writtenBy: w)
+        }
+    }
+
+    // MARK: array / map
+
+    @Test func arrayResolvesElements() throws {
+        let r = try parse(#"{"type":"array","items":"long"}"#)
+        let w = try parse(#"{"type":"array","items":"int"}"#)
+        let result = try r.resolveValue([Int32(1), Int32(2)], writtenBy: w) as? [Any]
+        #expect(result?.first as? Int64 == 1)
+    }
+
+    @Test func arrayNonArrayThrows() throws {
+        let r = try parse(#"{"type":"array","items":"long"}"#)
+        let w = try parse(#"{"type":"array","items":"int"}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue("bad", writtenBy: w)
+        }
+    }
+
+    @Test func mapResolvesValues() throws {
+        let r = try parse(#"{"type":"map","values":"long"}"#)
+        let w = try parse(#"{"type":"map","values":"int"}"#)
+        let result = try r.resolveValue(["k": Int32(9)], writtenBy: w) as? [String: Any]
+        #expect(result?["k"] as? Int64 == 9)
+    }
+
+    @Test func mapNonDictThrows() throws {
+        let r = try parse(#"{"type":"map","values":"long"}"#)
+        let w = try parse(#"{"type":"map","values":"int"}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue("bad", writtenBy: w)
+        }
+    }
+
+    // MARK: enum
+
+    @Test func enumSymbolInBoth() throws {
+        let r = try parse(#"{"type":"enum","name":"E","symbols":["A","B"]}"#)
+        let w = try parse(#"{"type":"enum","name":"E","symbols":["A","B"]}"#)
+        #expect(try r.resolveValue("A", writtenBy: w) as? String == "A")
+    }
+
+    @Test func enumSymbolUsesReaderDefault() throws {
+        let r = try parse(#"{"type":"enum","name":"E","symbols":["A","B"],"default":"A"}"#)
+        let w = try parse(#"{"type":"enum","name":"E","symbols":["A","B","C"]}"#)
+        #expect(try r.resolveValue("C", writtenBy: w) as? String == "A")
+    }
+
+    @Test func enumSymbolNotInWriterThrows() throws {
+        let r = try parse(#"{"type":"enum","name":"E","symbols":["A","B"]}"#)
+        let w = try parse(#"{"type":"enum","name":"E","symbols":["A","B"]}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue("X", writtenBy: w)
+        }
+    }
+
+    @Test func enumSymbolNotInReaderNoDefaultThrows() throws {
+        let r = try parse(#"{"type":"enum","name":"E","symbols":["A","B"]}"#)
+        let w = try parse(#"{"type":"enum","name":"E","symbols":["A","B","C"]}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue("C", writtenBy: w)
+        }
+    }
+
+    @Test func enumNonStringThrows() throws {
+        let r = try parse(#"{"type":"enum","name":"E","symbols":["A"]}"#)
+        let w = try parse(#"{"type":"enum","name":"E","symbols":["A"]}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue(0, writtenBy: w)
+        }
+    }
+
+    // MARK: fixed
+
+    @Test func fixedMatchingNames() throws {
+        let r = try parse(#"{"type":"fixed","name":"F","size":4}"#)
+        let w = try parse(#"{"type":"fixed","name":"F","size":4}"#)
+        let b: [UInt8] = [1, 2, 3, 4]
+        // When schemas are equal, exactlyMatches returns true → value returned
+        #expect(try r.resolveValue(b, writtenBy: w) as? [UInt8] == b)
+    }
+
+    @Test func fixedSizeMismatchThrows() throws {
+        let r = try parse(#"{"type":"fixed","name":"F","size":4}"#)
+        let w = try parse(#"{"type":"fixed","name":"F","size":8}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue([UInt8](repeating: 0, count: 8), writtenBy: w)
+        }
+    }
+
+    @Test func fixedNameMismatchThrows() throws {
+        let r = try parse(#"{"type":"fixed","name":"F1","size":4}"#)
+        let w = try parse(#"{"type":"fixed","name":"F2","size":4}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue([UInt8](repeating: 0, count: 4), writtenBy: w)
+        }
+    }
+
+    // MARK: bytes/fixed decimal interop
+
+    @Test func bytesDecimalFromFixedDecimal() throws {
+        let r = try parse(#"{"type":"bytes","logicalType":"decimal","precision":10,"scale":2}"#)
+        let w = try parse(#"{"type":"fixed","name":"D","size":8,"logicalType":"decimal","precision":10,"scale":2}"#)
+        let b: [UInt8] = [0x30, 0x39]
+        #expect(try r.resolveValue(b, writtenBy: w) as? [UInt8] == b)
+    }
+
+    @Test func fixedDecimalFromBytesDecimal() throws {
+        let r = try parse(#"{"type":"fixed","name":"D","size":8,"logicalType":"decimal","precision":10,"scale":2}"#)
+        let w = try parse(#"{"type":"bytes","logicalType":"decimal","precision":10,"scale":2}"#)
+        let b: [UInt8] = [0x30, 0x39]
+        #expect(try r.resolveValue(b, writtenBy: w) as? [UInt8] == b)
+    }
+
+    // MARK: union
+
+    @Test func readerUnionMatchesBranch() throws {
+        let r = try parse(#"["null","int"]"#)
+        let w = try parse(#"{"type":"int"}"#)
+        #expect(try r.resolveValue(Int32(5), writtenBy: w) as? Int32 == 5)
+    }
+
+    @Test func writerUnionMatchesBranch() throws {
+        let r = try parse(#"{"type":"int"}"#)
+        let w = try parse(#"["int","string"]"#)
+        #expect(try r.resolveValue(Int32(5), writtenBy: w) as? Int32 == 5)
+    }
+
+    @Test func writerUnionNoMatchThrows() throws {
+        let r = try parse(#"{"type":"boolean"}"#)
+        let w = try parse(#"["int","string"]"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue(true, writtenBy: w)
+        }
+    }
+
+    @Test func incompatibleSchemasThrow() throws {
+        let r = try parse(#"{"type":"int"}"#)
+        let w = try parse(#"{"type":"boolean"}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try r.resolveValue(true, writtenBy: w)
+        }
+    }
+
+    // MARK: record
+
+    @Test func recordResolvesByName() throws {
+        let r = try parse(#"{"type":"record","name":"R","fields":[{"name":"x","type":"long"}]}"#)
+        let w = try parse(#"{"type":"record","name":"R","fields":[{"name":"x","type":"int"}]}"#)
+        let dict = try r.resolveValue(["x": Int32(99)], writtenBy: w) as? [String: Any]
+        #expect(dict?["x"] as? Int64 == 99)
+    }
+
+    @Test func recordResolvesByAlias() throws {
+        let r = try parse(#"{"type":"record","name":"R","fields":[{"name":"newName","type":"int","aliases":["oldName"]}]}"#)
+        let w = try parse(#"{"type":"record","name":"R","fields":[{"name":"oldName","type":"int"}]}"#)
+        let dict = try r.resolveValue(["oldName": Int32(7)], writtenBy: w) as? [String: Any]
+        #expect(dict?["newName"] as? Int32 == 7)
+    }
+
+    @Test func recordUsesReaderDefaultForMissingField() throws {
+        let r = try parse(#"{"type":"record","name":"R","fields":[{"name":"a","type":"int"},{"name":"b","type":"int","default":0}]}"#)
+        let w = try parse(#"{"type":"record","name":"R","fields":[{"name":"a","type":"int"}]}"#)
+        let dict = try r.resolveValue(["a": Int32(1)], writtenBy: w) as? [String: Any]
+        #expect(dict?["b"] as? Int32 == 0)
+    }
+
+    @Test func recordMissingFieldNoDefaultThrows() throws {
+        let r = try parse(#"{"type":"record","name":"R","fields":[{"name":"a","type":"int"},{"name":"b","type":"int"}]}"#)
+        let w = try parse(#"{"type":"record","name":"R","fields":[{"name":"a","type":"int"}]}"#)
+        #expect(throws: AvroSchemaResolutionError.WriterFieldMissingWithoutDefaultValue) {
+            try r.resolveValue(["a": Int32(1)], writtenBy: w)
+        }
+    }
+
+    @Test func recordNonDictValueThrows() throws {
+        let s = try parse(#"{"type":"record","name":"R","fields":[{"name":"x","type":"int"}]}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try s.resolveValue("bad", writtenBy: s)
+        }
+    }
+
+    @Test func errorSchemaResolvesLikeRecord() throws {
+        let r = try parse(#"{"type":"error","name":"E","fields":[{"name":"msg","type":"string"}]}"#)
+        let w = try parse(#"{"type":"error","name":"E","fields":[{"name":"msg","type":"string"}]}"#)
+        let dict = try r.resolveValue(["msg": "oops"], writtenBy: w) as? [String: Any]
+        #expect(dict?["msg"] as? String == "oops")
+    }
+}
+
+// MARK: - AvroSchema+Evolution: defaultValue(from:)
+
+@Suite("AvroSchema+Evolution – defaultValue")
+struct EvolutionDefaultValueTests {
+
+    @Test func nullFromNull() throws {
+        #expect(try parse(#""null""#).defaultValue(from: .null) == nil)
+    }
+
+    @Test func nullFromNonNullThrows() throws {
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try parse(#""null""#).defaultValue(from: .bool(true))
+        }
+    }
+
+    @Test func boolFromBool() throws {
+        #expect(try parse(#""boolean""#).defaultValue(from: .bool(false)) as? Bool == false)
+    }
+
+    @Test func boolFromNonBoolThrows() throws {
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try parse(#""boolean""#).defaultValue(from: .null)
+        }
+    }
+
+    @Test func intFromInt() throws {
+        #expect(try parse(#"{"type":"int"}"#).defaultValue(from: .int(42)) as? Int32 == 42)
+    }
+
+    @Test func intFromDouble() throws {
+        // jsonInt double branch
+        #expect(try parse(#"{"type":"int"}"#).defaultValue(from: .double(5.0)) as? Int32 == 5)
+    }
+
+    @Test func intFromStringThrows() throws {
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try parse(#"{"type":"int"}"#).defaultValue(from: .string("x"))
+        }
+    }
+
+    @Test func intLogicalDate() throws {
+        #expect(try parse(#"{"type":"int","logicalType":"date"}"#).defaultValue(from: .int(1)) is Date)
+    }
+
+    @Test func intLogicalTimeMillis() throws {
+        #expect(try parse(#"{"type":"int","logicalType":"time-millis"}"#).defaultValue(from: .int(0)) is Date)
+    }
+
+    @Test func longDefault() throws {
+        #expect(try parse(#"{"type":"long"}"#).defaultValue(from: .int(99)) as? Int64 == 99)
+    }
+
+    @Test func longTimestampMillis() throws {
+        #expect(try parse(#"{"type":"long","logicalType":"timestamp-millis"}"#).defaultValue(from: .int(0)) is Date)
+    }
+
+    @Test func longTimestampMicros() throws {
+        #expect(try parse(#"{"type":"long","logicalType":"timestamp-micros"}"#).defaultValue(from: .int(0)) is Date)
+    }
+
+    @Test func longTimeMicros() throws {
+        #expect(try parse(#"{"type":"long","logicalType":"time-micros"}"#).defaultValue(from: .int(0)) is Date)
+    }
+
+    @Test func floatFromDouble() throws {
+        #expect(try parse(#"{"type":"float"}"#).defaultValue(from: .double(1.5)) as? Float == 1.5)
+    }
+
+    @Test func floatFromInt() throws {
+        // jsonDouble int branch
+        #expect(try parse(#"{"type":"float"}"#).defaultValue(from: .int(2)) as? Float == 2.0)
+    }
+
+    @Test func floatFromStringThrows() throws {
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try parse(#"{"type":"float"}"#).defaultValue(from: .string("x"))
+        }
+    }
+
+    @Test func doubleDefault() throws {
+        #expect(try parse(#"{"type":"double"}"#).defaultValue(from: .double(2.5)) as? Double == 2.5)
+    }
+
+    @Test func stringDefault() throws {
+        #expect(try parse(#"{"type":"string"}"#).defaultValue(from: .string("hi")) as? String == "hi")
+    }
+
+    @Test func stringFromNonStringThrows() throws {
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try parse(#"{"type":"string"}"#).defaultValue(from: .int(1))
+        }
+    }
+
+    @Test func bytesDefault() throws {
+        #expect(try parse(#"{"type":"bytes"}"#).defaultValue(from: .string("ab")) as? [UInt8] == Array("ab".utf8))
+    }
+
+    @Test func bytesFromNonStringThrows() throws {
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try parse(#"{"type":"bytes"}"#).defaultValue(from: .int(1))
+        }
+    }
+
+    @Test func fixedCorrectSize() throws {
+        let s = try parse(#"{"type":"fixed","name":"F","size":2}"#)
+        #expect(try s.defaultValue(from: .string("ab")) as? [UInt8] == Array("ab".utf8))
+    }
+
+    @Test func fixedWrongSizeThrows() throws {
+        let s = try parse(#"{"type":"fixed","name":"F","size":4}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try s.defaultValue(from: .string("ab"))
+        }
+    }
+
+    @Test func fixedNonStringThrows() throws {
+        let s = try parse(#"{"type":"fixed","name":"F","size":4}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try s.defaultValue(from: .int(0))
+        }
+    }
+
+    @Test func enumValidSymbol() throws {
+        let s = try parse(#"{"type":"enum","name":"E","symbols":["A","B"]}"#)
+        #expect(try s.defaultValue(from: .string("B")) as? String == "B")
+    }
+
+    @Test func enumInvalidSymbolThrows() throws {
+        let s = try parse(#"{"type":"enum","name":"E","symbols":["A","B"]}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try s.defaultValue(from: .string("Z"))
+        }
+    }
+
+    @Test func enumNonStringThrows() throws {
+        let s = try parse(#"{"type":"enum","name":"E","symbols":["A"]}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try s.defaultValue(from: .int(0))
+        }
+    }
+
+    @Test func arrayDefault() throws {
+        let s = try parse(#"{"type":"array","items":"int"}"#)
+        let result = try s.defaultValue(from: .array([.int(1), .int(2)])) as? [Any]
+        #expect(result?.count == 2)
+        #expect(result?.first as? Int32 == 1)
+    }
+
+    @Test func arrayNonArrayThrows() throws {
+        let s = try parse(#"{"type":"array","items":"int"}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try s.defaultValue(from: .object([:]))
+        }
+    }
+
+    @Test func mapDefault() throws {
+        let s = try parse(#"{"type":"map","values":"int"}"#)
+        let result = try s.defaultValue(from: .object(["k": .int(3)])) as? [String: Any]
+        #expect(result?["k"] as? Int32 == 3)
+    }
+
+    @Test func mapNonObjectThrows() throws {
+        let s = try parse(#"{"type":"map","values":"int"}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try s.defaultValue(from: .array([]))
+        }
+    }
+
+    @Test func recordAllFields() throws {
+        let s = try parse(#"{"type":"record","name":"R","fields":[{"name":"x","type":"int"},{"name":"y","type":"string"}]}"#)
+        let result = try s.defaultValue(from: .object(["x": .int(1), "y": .string("hi")])) as? [String: Any]
+        #expect(result?["x"] as? Int32 == 1)
+        #expect(result?["y"] as? String == "hi")
+    }
+
+    @Test func recordFieldFromDefault() throws {
+        let s = try parse(#"{"type":"record","name":"R","fields":[{"name":"x","type":"int","default":5}]}"#)
+        let result = try s.defaultValue(from: .object([:])) as? [String: Any]
+        #expect(result?["x"] as? Int32 == 5)
+    }
+
+    @Test func recordMissingFieldNoDefaultThrows() throws {
+        let s = try parse(#"{"type":"record","name":"R","fields":[{"name":"x","type":"int"}]}"#)
+        #expect(throws: AvroSchemaResolutionError.WriterFieldMissingWithoutDefaultValue) {
+            try s.defaultValue(from: .object([:]))
+        }
+    }
+
+    @Test func recordNonObjectThrows() throws {
+        let s = try parse(#"{"type":"record","name":"R","fields":[{"name":"x","type":"int"}]}"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try s.defaultValue(from: .array([]))
+        }
+    }
+
+    @Test func errorSchemaDefault() throws {
+        let s = try parse(#"{"type":"error","name":"E","fields":[{"name":"m","type":"string"}]}"#)
+        let result = try s.defaultValue(from: .object(["m": .string("err")])) as? [String: Any]
+        #expect(result?["m"] as? String == "err")
+    }
+
+    @Test func unionDefaultFromFirstBranch() throws {
+        let s = try parse(#"["null","int"]"#)
+        #expect(try s.defaultValue(from: .null) == nil)
+    }
+
+    @Test func unionMismatchedBranchThrows() throws {
+        let s = try parse(#"["null"]"#)
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try s.defaultValue(from: .int(1))
+        }
+    }
+
+    @Test func unknownSchemaDefaultThrows() throws {
+        let s = AvroSchema.unknownSchema(AvroSchema.UnknownSchema("test"))
+        #expect(throws: AvroSchemaResolutionError.SchemaMismatch) {
+            try s.defaultValue(from: .null)
+        }
+    }
+}

--- a/Tests/SwiftAvroCoreTests/LogicalTypesTests.swift
+++ b/Tests/SwiftAvroCoreTests/LogicalTypesTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import Foundation
+@testable import SwiftAvroCore
+
+struct LogicalTypesTests {
+    let avro = Avro()
+
+    @Test("Date logical type round-trips")
+    func testDateRoundTrip() throws {
+        let schema = try #require(avro.decodeSchema(schema: #"{"type":"int","logicalType":"date"}"#))
+        let date = Date(timeIntervalSince1970: 86400 * 10) // 10 days after epoch
+        let encoded = try avro.encodeFrom(date, schema: schema)
+        let decoded = try avro.decodeFrom(from: encoded, schema: schema) as! Date
+        #expect(decoded == date)
+    }
+
+    @Test("Date logical type decodes through typed API")
+    func testDateTypedDecode() throws {
+        let schema = try #require(avro.decodeSchema(schema: #"{"type":"int","logicalType":"date"}"#))
+        let date = Date(timeIntervalSince1970: 86400 * 10)
+        let encoded = try avro.encodeFrom(date, schema: schema)
+        let decoded: Date = try avro.decodeFrom(from: encoded, schema: schema)
+        #expect(decoded == date)
+    }
+
+    @Test("Date logical type decodes in arrays")
+    func testDateArrayDecode() throws {
+        let schema = try #require(avro.decodeSchema(schema: #"{"type":"array","items":{"type":"long","logicalType":"timestamp-millis"}}"#))
+        let values = [
+            Date(timeIntervalSince1970: 1622548800.123),
+            Date(timeIntervalSince1970: 1622548801.456)
+        ]
+        let encoded = try avro.encodeFrom(values, schema: schema)
+        let decoded: [Date] = try avro.decodeFrom(from: encoded, schema: schema)
+        #expect(decoded == values)
+    }
+
+    @Test("Timestamp-millis logical type round-trips")
+    func testTimestampMillisRoundTrip() throws {
+        let schema = try #require(avro.decodeSchema(schema: #"{"type":"long","logicalType":"timestamp-millis"}"#))
+        let date = Date(timeIntervalSince1970: 1622548800.123) // 2021-06-01T12:00:00.123Z
+        let encoded = try avro.encodeFrom(date, schema: schema)
+        let decoded = try avro.decodeFrom(from: encoded, schema: schema) as! Date
+        #expect(abs(decoded.timeIntervalSince1970 - date.timeIntervalSince1970) < 0.001)
+    }
+
+    @Test("Timestamp-micros logical type round-trips")
+    func testTimestampMicrosRoundTrip() throws {
+        let schema = try #require(avro.decodeSchema(schema: #"{"type":"long","logicalType":"timestamp-micros"}"#))
+        let date = Date(timeIntervalSince1970: 1622548800.123456)
+        let encoded = try avro.encodeFrom(date, schema: schema)
+        let decoded = try avro.decodeFrom(from: encoded, schema: schema) as! Date
+        #expect(abs(decoded.timeIntervalSince1970 - date.timeIntervalSince1970) < 0.000001)
+    }
+
+    @Test("Time-millis logical type round-trips")
+    func testTimeMillisRoundTrip() throws {
+        let schema = try #require(avro.decodeSchema(schema: #"{"type":"int","logicalType":"time-millis"}"#))
+        let date = Date(timeIntervalSince1970: 3600 * 1000) // 1000 seconds into the day
+        let encoded = try avro.encodeFrom(date, schema: schema)
+        let decoded = try avro.decodeFrom(from: encoded, schema: schema) as! Date
+        #expect(decoded.timeIntervalSince1970.truncatingRemainder(dividingBy: 86400) ==
+                date.timeIntervalSince1970.truncatingRemainder(dividingBy: 86400))
+    }
+
+    @Test("Decimal bytes logical type round-trips")
+    func testDecimalBytesRoundTrip() throws {
+        let schema = try #require(avro.decodeSchema(schema: #"{"type":"bytes","logicalType":"decimal","precision":10,"scale":2}"#))
+        let value: Decimal = 123.45
+        let encoded = try avro.encodeFrom(value, schema: schema)
+        let decoded = try avro.decodeFrom(from: encoded, schema: schema) as! Decimal
+        #expect(decoded == value)
+    }
+
+    @Test("Decimal bytes logical type supports values larger than Int64")
+    func testLargeDecimalBytesRoundTrip() throws {
+        let schema = try #require(avro.decodeSchema(schema: #"{"type":"bytes","logicalType":"decimal","precision":24,"scale":2}"#))
+        let value = try #require(Decimal(string: "12345678901234567890.12"))
+        let encoded = try avro.encodeFrom(value, schema: schema)
+        let decoded = try avro.decodeFrom(from: encoded, schema: schema) as! Decimal
+        #expect(decoded == value)
+    }
+
+    @Test("Decimal fixed logical type round-trips")
+    func testDecimalFixedRoundTrip() throws {
+        let schema = try #require(avro.decodeSchema(schema: #"{"type":"fixed","size":4,"logicalType":"decimal","precision":10,"scale":2}"#))
+        let value: Decimal = 123.45
+        let encoded = try avro.encodeFrom(value, schema: schema)
+        let decoded = try avro.decodeFrom(from: encoded, schema: schema) as! Decimal
+        #expect(decoded == value)
+    }
+}


### PR DESCRIPTION
  Schema Resolution / Evolution                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                         
  New feature: Schema resolution API (AvroSchema+Evolution.swift, SwiftAvroCore.swift, AvroDecodable.swift)                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                         
  Added full schema resolution (reader/writer reconciliation) per the Avro specification:                                                                                                                                                                                                                                
                  
  - AvroSchema.resolveValue(_:writtenBy:) — resolves a decoded value from a writer schema into the reader schema, with support for numeric promotions (int→long→float→double), bytes/string interchange, union resolution, record field matching with defaults, enum symbol defaulting, and recursive array/map/fixed    
  resolution.     
  - SwiftAvroCore gains a public decode<T>(_:from:as:writtenBy:) entry point for decoding data written with a different (compatible) schema.                                                                                                                                                                             
  - New error type AvroSchemaResolutionError.SchemaMismatch for incompatible schema pairs.                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                         
  ---                                                                                                                                                                                                                                                                                                                    
  Bug Fixes & Robustness (commit 35a07ce)                                                                                                                                                                                                                                                                                
                                         
  AvroPrimitiveDecoder — negative-length guards
                                                                                                                                                                                                                                                                                                                         
  - decode() -> [UInt8] now throws BinaryDecodingError.malformedAvro when the zig-zag decoded length is negative, preventing an underflow into the bounds check.                                                                                                                                                         
  - decode(fixedSize:) applies the same guard for negative fixedSize inputs.                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                         
  AvroSchema+Codable — encoding cleanup                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                         
  - encode(jsonEncoder:) return type changed from Data? to non-optional Data; all internal helpers (encodePrimitive, encodeLogicalType) updated accordingly, eliminating a spurious optional unwrap at every call site.                                                                                                  
  - String.data(using: .utf8) replaced with the always-succeeding Data(string.utf8) throughout.
  - RecordSchema.addField now silently returns (rather than crashing via preconditionFailure) when the field has no name.                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                         
  SwiftAvroCore — Object Container & map decoding                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                         
  - makeFileObjectContainer(schema:syncMarker:) — new syncMarker parameter lets callers supply a deterministic 16-byte marker (useful for reproducible tests and interoperability).                                                                                                                                      
  - AvroDataReader.decode(schema:) now routes map-typed schemas through AvroDecodable init, fixing a mismatch between the Avro map block layout and Swift's Dictionary.init(from:) keyed-container path.
  - decodeContinue early-exits with AvroCodingError.decodingFailed on empty data before entering withUnsafeBytes, removing a forced-unwrap.                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                         
  New error types                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                         
  - AvroContainerError.invalidSyncMarkerLength(Int) — thrown by ObjectContainer.encode when the sync marker is not exactly 16 bytes.                                                                                                                                                                                     
  - AvroContainerError.syncMarkerMismatch(blockIndex:) — thrown by ObjectContainer.decode when a block's trailing marker does not match the header marker.
                                                                                                                                                                                                                                                                                                                         
  ---             
  Test Coverage                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                         
  ObjectContainer, IPC, and Codable (commit 35a07ce, +375 lines / −134 lines across 15 files)
                                                                                                                                                                                                                                                                                                                         
  - AvroFileObjectTest: sync-marker round-trip tests; new tests for encode rejection of bad-length markers and decode detection of corrupted block markers.                                                                                                                                                              
  - AvroPrimitiveDecoderTest: negative-length error paths for bytes and fixed decoding; varint exhausted-buffer path.                                                                                                                                                                                                    
  - AvroIPCContextTest: AvroIPCContext.standard factory with and without optional parameters.                                                                                                                                                                                                                            
  - AvroProtocolTest: Message.validate one-way branches; StringCodingKey(intValue:) path.                                                                                                                                                                                                                                
  - AvroRequestResponseTest: full non-empty requestMeta / responseMeta round-trip through encodeCall + decodeCall + encodeResponse + decodeResponse; test fixtures migrated to canonical MessageConstant schemas.                                                                                                        
  - AvroSchemaCodingTest: missing type key in field, JSON number as top-level schema, addField with unnamed schema.                                                                                                                                                                                                      
  - SwiftAvroCoreTest: typed/Any/map decode on empty data; ObjectContainer block-layout tests updated to deterministic sync markers.                                                                                                                                                                                     
  - AvroFingerPrintTest: migrated to static AvroFingerprint.fingerprint64(_:) API; added FingerprintFunction typealias test.                                                                                                                                                                                             
  - New TestHelpers.swift: shared makeSyncMarker() and createAvroWithMarker(_:syncMarker:) utilities.                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                         
  Schema resolution coverage (commit 9ead056, +813 lines)                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                         
  Comprehensive tests covering all resolution paths: numeric promotions, union unwrapping, record evolution (added/removed fields, defaults), enum defaulting, and error cases.   