### PR TITLE
task #50 Add SwiftAvroRpc as a new SPM product

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,22 +1,36 @@
-# This workflow will build a Swift project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
-
 name: Swift 6 Build
 on: [push, pull_request]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest # or macos-latest
+  build-and-test:
+    name: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS: full build + all tests (includes SwiftAvroRpc with Apple Compression codecs)
+          - os: macos-latest
+            test-args: ""
+          # Linux: full build + Core tests only (Apple Compression framework unavailable)
+          - os: ubuntu-latest
+            test-args: "--filter SwiftAvroCoreTests"
+
+    runs-on: ${{ matrix.os }}
+
     steps:
-      - uses: actions/checkout@v6
-      
+      - uses: actions/checkout@v4
+
       - name: Setup Swift 6
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: "6.2" # You can also use "6.1" or "6.2" for newer versions
+          swift-version: "6.1"
+
+      - name: Install OpenSSL (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libssl-dev
 
       - name: Build
         run: swift build -c release
 
       - name: Run Tests
-        run: swift test
+        run: swift test ${{ matrix.test-args }}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "03b6d3a1a4a1aadb57f142340b9ec961a2802a18d3b478be1dd088f5397e560e",
+  "pins" : [
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftAvroCore",
     platforms: [
-        .macOS(.v10_13),
+        .macOS(.v12),
         .iOS(.v15)
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,4 @@
 // swift-tools-version:6.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 import PackageDescription
 
 let package = Package(
@@ -10,15 +8,38 @@ let package = Package(
         .iOS(.v15)
     ],
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "SwiftAvroCore",
-            targets: ["SwiftAvroCore"]),
+        .library(name: "SwiftAvroCore", targets: ["SwiftAvroCore"]),
+        .library(name: "SwiftAvroRpc",  targets: ["SwiftAvroRpc"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git",     from: "2.82.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.28.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git",  from: "3.0.0"),
     ],
     targets: [
+        // MARK: - SwiftAvroCore
         .target(name: "SwiftAvroCore"),
         .testTarget(
             name: "SwiftAvroCoreTests",
             dependencies: ["SwiftAvroCore"]),
+
+        // MARK: - SwiftAvroRpc
+        .target(
+            name: "SwiftAvroRpc",
+            dependencies: [
+                "SwiftAvroCore",
+                .product(name: "NIO",     package: "swift-nio"),
+                .product(name: "NIOHTTP1",package: "swift-nio"),
+                .product(name: "NIOSSL",  package: "swift-nio-ssl"),
+                .product(name: "Crypto",  package: "swift-crypto",
+                         condition: .when(platforms: [.linux])),
+            ],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .testTarget(
+            name: "SwiftAvroRpcTests",
+            dependencies: ["SwiftAvroRpc"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
     ]
 )

--- a/Sources/SwiftAvroCore/AvroError.swift
+++ b/Sources/SwiftAvroCore/AvroError.swift
@@ -122,10 +122,12 @@ public enum AvroCodingError: Error {
 }
 
 /// Errors raised by the Avro Object Container File reader/writer.
-public enum AvroContainerError: Error, Equatable {
+public enum AvroContainerError: Error, Sendable, Equatable {
     /// The supplied sync marker is not 16 bytes long, as required by the Avro spec.
     case invalidSyncMarkerLength(Int)
     /// A data block's trailing sync marker did not match the marker declared in the file header.
     /// `blockIndex` is the zero-based index of the offending block in the decoded stream.
     case syncMarkerMismatch(blockIndex: Int)
+    case encodingFailed(String)
+    case decodingFailed(String)
 }

--- a/Sources/SwiftAvroCore/FileObject/AvroFileObjectContainer.swift
+++ b/Sources/SwiftAvroCore/FileObject/AvroFileObjectContainer.swift
@@ -1,0 +1,176 @@
+//
+//  FileObject/AvroFileObjectContainer.swift
+//  SwiftAvroCore
+//
+
+import Foundation
+
+// MARK: - AvroFileObjectContainer
+
+/// Actor that reads and writes Avro Object Container Files.
+///
+/// Wraps ``ObjectContainer``, isolating all mutable state behind actor serialisation.
+/// The codec is injected at construction time; use ``NullCodec`` for uncompressed files
+/// or any ``CodecProtocol``-conforming type for compression.
+///
+/// Platform-specific codecs (deflate, lz4, lzfse via Apple's `Compression` framework)
+/// are provided by `SwiftAvroRpc`.
+public actor AvroFileObjectContainer {
+    private var container: ObjectContainer
+    private let codec: any CodecProtocol
+
+    /// Creates an uncompressed container (``NullCodec``).
+    ///
+    /// - Parameters:
+    ///   - schema: The Avro schema JSON string describing the record type.
+    ///   - syncMarker: 16-byte sync marker. Must be exactly 16 bytes.
+    /// - Throws: ``AvroContainerError/encodingFailed(_:)`` if the sync marker length is wrong.
+    public init(schema: String, syncMarker: [UInt8]) throws {
+        try self.init(schema: schema, codec: NullCodec(), syncMarker: syncMarker)
+    }
+
+    /// Creates a container with a directly injected codec.
+    ///
+    /// - Parameters:
+    ///   - schema: The Avro schema JSON string describing the record type.
+    ///   - codec: Any ``CodecProtocol``-conforming value. Use ``NullCodec`` for no compression.
+    ///   - syncMarker: 16-byte sync marker. Must be exactly 16 bytes.
+    /// - Throws: ``AvroContainerError/encodingFailed(_:)`` if the sync marker length is wrong.
+    public init(
+        schema: String,
+        codec: any CodecProtocol,
+        syncMarker: [UInt8]
+    ) throws {
+        guard syncMarker.count == AvroReservedConstants.syncSize else {
+            throw AvroContainerError.encodingFailed(
+                "syncMarker must be exactly \(AvroReservedConstants.syncSize) bytes"
+            )
+        }
+        self.codec     = codec
+        self.container = ObjectContainer(schema: schema, syncMarker: syncMarker)
+    }
+
+    // MARK: - Write
+
+    /// Appends a single object to the current pending block.
+    public func addObject<T: Codable & Sendable>(_ value: T) throws(AvroContainerError) {
+        do {
+            try container.addObject(value, avro: Avro())
+        } catch {
+            throw .encodingFailed(error.localizedDescription)
+        }
+    }
+
+    /// Appends multiple objects, distributing them into blocks of `objectsPerBlock` each.
+    public func addObjectsToBlocks<T: Codable & Sendable>(
+        _ values: [T],
+        objectsPerBlock: Int = AvroReservedConstants.defaultSyncInterval
+    ) throws(AvroContainerError) {
+        do {
+            try container.addObjectsToBlocks(
+                values,
+                objectsInBlock: objectsPerBlock,
+                avro: Avro()
+            )
+        } catch {
+            throw .encodingFailed(error.localizedDescription)
+        }
+    }
+
+    /// Encodes all objects and returns a complete Avro container file as `Data`.
+    public func write<T: Codable & Sendable>(objects: [T]) throws(AvroContainerError) -> Data {
+        do {
+            for obj in objects {
+                try container.addObject(obj, avro: Avro())
+            }
+        } catch {
+            throw .encodingFailed(error.localizedDescription)
+        }
+        return try flush()
+    }
+
+    /// Serialises the current pending block to `Data`.
+    public func flush() throws(AvroContainerError) -> Data {
+        do {
+            return try container.encode(avro: Avro(), codec: codec)
+        } catch {
+            throw .encodingFailed(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Read
+
+    /// Parses a complete container file and returns all decoded objects.
+    public func read<T: Codable & Sendable>(
+        from data: Data,
+        as type: T.Type
+    ) throws(AvroContainerError) -> [T] {
+        do {
+            let avro = Avro()
+            try container.decode(from: data, avro: avro, codec: codec)
+            return try container.decodeAll(T.self, avro: avro)
+        } catch {
+            throw .decodingFailed(error.localizedDescription)
+        }
+    }
+
+    /// Returns an `AsyncThrowingStream` that yields one decoded object at a time.
+    public func stream<T: Codable & Sendable>(
+        from data: Data,
+        as type: T.Type
+    ) -> AsyncThrowingStream<T, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    let objects = try self.read(from: data, as: type)
+                    for object in objects { continuation.yield(object) }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Parses a container file with schema evolution.
+    ///
+    /// Fields absent in the writer schema are filled from defaults in `readerSchemaJson`;
+    /// extra writer fields are discarded.
+    public func read<T: Codable & Sendable>(
+        from data: Data,
+        as type: T.Type,
+        readerSchema readerSchemaJson: String
+    ) throws(AvroContainerError) -> [T] {
+        let avro = Avro()
+        guard let readerSchema = avro.newSchema(schema: readerSchemaJson) else {
+            throw .decodingFailed("Invalid reader schema")
+        }
+        do {
+            try container.decode(from: data, avro: avro, codec: codec)
+            return try container.decodeAll(T.self, avro: avro, readerSchema: readerSchema)
+        } catch let e as AvroContainerError {
+            throw e
+        } catch {
+            throw .decodingFailed(error.localizedDescription)
+        }
+    }
+
+    /// Returns an `AsyncThrowingStream` that yields one schema-evolved object at a time.
+    public func stream<T: Codable & Sendable>(
+        from data: Data,
+        as type: T.Type,
+        readerSchema readerSchemaJson: String
+    ) -> AsyncThrowingStream<T, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    let objects = try self.read(from: data, as: type, readerSchema: readerSchemaJson)
+                    for object in objects { continuation.yield(object) }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/Sources/SwiftAvroCore/FileObject/AvroFileObjectContainer.swift
+++ b/Sources/SwiftAvroCore/FileObject/AvroFileObjectContainer.swift
@@ -53,11 +53,11 @@ public actor AvroFileObjectContainer {
     // MARK: - Write
 
     /// Appends a single object to the current pending block.
-    public func addObject<T: Codable & Sendable>(_ value: T) throws(AvroContainerError) {
+    public func addObject<T: Codable & Sendable>(_ value: T) throws {
         do {
             try container.addObject(value, avro: Avro())
         } catch {
-            throw .encodingFailed(error.localizedDescription)
+            throw AvroContainerError.encodingFailed(error.localizedDescription)
         }
     }
 
@@ -65,7 +65,7 @@ public actor AvroFileObjectContainer {
     public func addObjectsToBlocks<T: Codable & Sendable>(
         _ values: [T],
         objectsPerBlock: Int = AvroReservedConstants.defaultSyncInterval
-    ) throws(AvroContainerError) {
+    ) throws {
         do {
             try container.addObjectsToBlocks(
                 values,
@@ -73,28 +73,28 @@ public actor AvroFileObjectContainer {
                 avro: Avro()
             )
         } catch {
-            throw .encodingFailed(error.localizedDescription)
+            throw AvroContainerError.encodingFailed(error.localizedDescription)
         }
     }
 
     /// Encodes all objects and returns a complete Avro container file as `Data`.
-    public func write<T: Codable & Sendable>(objects: [T]) throws(AvroContainerError) -> Data {
+    public func write<T: Codable & Sendable>(objects: [T]) throws -> Data {
         do {
             for obj in objects {
                 try container.addObject(obj, avro: Avro())
             }
         } catch {
-            throw .encodingFailed(error.localizedDescription)
+            throw AvroContainerError.encodingFailed(error.localizedDescription)
         }
         return try flush()
     }
 
     /// Serialises the current pending block to `Data`.
-    public func flush() throws(AvroContainerError) -> Data {
+    public func flush() throws -> Data {
         do {
             return try container.encode(avro: Avro(), codec: codec)
         } catch {
-            throw .encodingFailed(error.localizedDescription)
+            throw AvroContainerError.encodingFailed(error.localizedDescription)
         }
     }
 
@@ -104,13 +104,13 @@ public actor AvroFileObjectContainer {
     public func read<T: Codable & Sendable>(
         from data: Data,
         as type: T.Type
-    ) throws(AvroContainerError) -> [T] {
+    ) throws -> [T] {
         do {
             let avro = Avro()
             try container.decode(from: data, avro: avro, codec: codec)
             return try container.decodeAll(T.self, avro: avro)
         } catch {
-            throw .decodingFailed(error.localizedDescription)
+            throw AvroContainerError.decodingFailed(error.localizedDescription)
         }
     }
 
@@ -140,10 +140,10 @@ public actor AvroFileObjectContainer {
         from data: Data,
         as type: T.Type,
         readerSchema readerSchemaJson: String
-    ) throws(AvroContainerError) -> [T] {
+    ) throws -> [T] {
         let avro = Avro()
         guard let readerSchema = avro.newSchema(schema: readerSchemaJson) else {
-            throw .decodingFailed("Invalid reader schema")
+            throw AvroContainerError.decodingFailed("Invalid reader schema")
         }
         do {
             try container.decode(from: data, avro: avro, codec: codec)
@@ -151,7 +151,7 @@ public actor AvroFileObjectContainer {
         } catch let e as AvroContainerError {
             throw e
         } catch {
-            throw .decodingFailed(error.localizedDescription)
+            throw AvroContainerError.decodingFailed(error.localizedDescription)
         }
     }
 

--- a/Sources/SwiftAvroCore/IPC/DataFraming.swift
+++ b/Sources/SwiftAvroCore/IPC/DataFraming.swift
@@ -1,0 +1,80 @@
+//
+//  IPC/DataFraming.swift
+//  SwiftAvroCore
+//
+
+import Foundation
+
+extension Data {
+
+    /// Parses Avro IPC frames from raw data.
+    ///
+    /// Each frame is prefixed with a big-endian `UInt32` byte count.
+    /// A zero-length prefix signals the end of the frame sequence.
+    public func deFraming() -> [Data] {
+        var frames: [Data] = []
+        var offset = 0
+
+        while offset + 4 <= count {
+            let length: UInt32 = (UInt32(self[offset])     << 24) |
+                                 (UInt32(self[offset + 1]) << 16) |
+                                 (UInt32(self[offset + 2]) <<  8) |
+                                  UInt32(self[offset + 3])
+            offset += 4
+
+            if length == 0 { break }
+
+            let payloadEnd = offset + Int(length)
+            guard payloadEnd <= count else { break }
+            frames.append(self[offset..<payloadEnd])
+            offset = payloadEnd
+        }
+        return frames
+    }
+
+    /// Deframes and concatenates all frame payloads into a single `Data`.
+    ///
+    /// Equivalent to `deFraming().reduce(Data(), +)` but avoids the intermediate
+    /// array and per-step copies.
+    public func deFramed() -> Data {
+        var out = Data()
+        var offset = 0
+        while offset + 4 <= count {
+            let length: UInt32 = (UInt32(self[offset])     << 24) |
+                                 (UInt32(self[offset + 1]) << 16) |
+                                 (UInt32(self[offset + 2]) <<  8) |
+                                  UInt32(self[offset + 3])
+            offset += 4
+            if length == 0 { break }
+            let payloadEnd = offset + Int(length)
+            guard payloadEnd <= count else { break }
+            out.append(contentsOf: self[offset..<payloadEnd])
+            offset = payloadEnd
+        }
+        return out
+    }
+
+    /// Wraps the receiver in Avro IPC framing, splitting into chunks of at most
+    /// `maxFrameLength` bytes each, and appending the mandatory zero-length terminator.
+    public func framing(maxFrameLength: Int = 16 * 1024) -> Data {
+        guard maxFrameLength > 0 else { return Data([0, 0, 0, 0]) }
+        var result = Data()
+        result.reserveCapacity(count + (count / maxFrameLength + 2) * 4)
+        var offset = 0
+        while offset < count {
+            let chunkSize = Swift.min(count - offset, maxFrameLength)
+            result.append(contentsOf: Int32(chunkSize).bigEndianBytes)
+            let end = offset + chunkSize
+            result.append(self[offset..<end])
+            offset = end
+        }
+        result.append(contentsOf: Int32(0).bigEndianBytes)
+        return result
+    }
+}
+
+private extension FixedWidthInteger {
+    var bigEndianBytes: [UInt8] {
+        withUnsafeBytes(of: self.bigEndian) { Array($0) }
+    }
+}

--- a/Sources/SwiftAvroRpc/FileIO/AppleBuildinCodec.swift
+++ b/Sources/SwiftAvroRpc/FileIO/AppleBuildinCodec.swift
@@ -1,0 +1,152 @@
+//
+//  FileIO/AppleBuiltinCodec.swift
+//
+//  Created by Yang Liu on  04/04/2026.
+//  Copyright © 2026 Yang Liu.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+#if canImport(Compression)
+import Compression
+#endif
+import SwiftAvroCore
+
+// MARK: - Errors
+
+/// Errors thrown by codec operations.
+/// Used as the typed-throw error for ``BuiltinCodec`` and ``CodecFactory``.
+enum AvroCodecError: Error, Sendable, Equatable {
+    /// The requested codec name is not supported.
+    case unsupportedCodec(String)
+    /// The input data was empty.
+    case emptySourceData
+    /// The compression algorithm failed to produce output.
+    case compressionFailed
+    /// The decompression algorithm failed to produce output.
+    case decompressionFailed
+}
+
+// MARK: - Codecs
+
+#if canImport(Compression)
+/// A codec backed by Apple's `Compression` framework.
+/// Supports deflate (ZLIB), LZ4, LZMA (xz), and LZFSE algorithms.
+struct BuiltinCodec: CodecProtocol, Sendable {
+    let name: String
+    private let decompressBufferSize: Int
+
+    private var algorithm: compression_algorithm {
+        switch name {
+        case AvroReservedConstants.deflateCodec: return COMPRESSION_ZLIB
+        case AvroReservedConstants.xzCodec:      return COMPRESSION_LZMA
+        case AvroReservedConstants.lz4Codec:     return COMPRESSION_LZ4
+        case AvroReservedConstants.lzfseCodec:   return COMPRESSION_LZFSE
+        default:                                  return COMPRESSION_BROTLI
+        }
+    }
+
+    /// Creates a codec for the given Avro codec name.
+    init(codecName: String, decompressBufferSize: Int = 1024 << 3) {
+        self.name = codecName
+        self.decompressBufferSize = decompressBufferSize
+    }
+
+    /// - Throws: ``AvroCodecError/emptySourceData`` or ``AvroCodecError/compressionFailed``.
+    func compress(data: Data) throws(AvroCodecError) -> Data {
+        guard !data.isEmpty else { throw .emptySourceData }
+        let src = [UInt8](data)
+        let capacity = max(src.count * 2, 1024)
+        let dst = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+        defer { dst.deallocate() }
+        let written = compression_encode_buffer(
+            dst, capacity, src, src.count, nil, algorithm
+        )
+        guard written > 0 else { throw .compressionFailed }
+        return Data(bytes: dst, count: written)
+    }
+
+    /// - Throws: ``AvroCodecError/emptySourceData`` or ``AvroCodecError/decompressionFailed``.
+    func decompress(data: Data) throws(AvroCodecError) -> Data {
+        guard !data.isEmpty else { throw .emptySourceData }
+        let src = [UInt8](data)
+        var dstSize = max(data.count * 4, 65536)
+        while dstSize <= 16 * 1024 * 1024 {
+            let dst = UnsafeMutablePointer<UInt8>.allocate(capacity: dstSize)
+            defer { dst.deallocate() }
+            let written = compression_decode_buffer(
+                dst, dstSize, src, src.count, nil, algorithm
+            )
+            if written > 0 { return Data(bytes: dst, count: written) }
+            if written == 0 { break }
+            dstSize *= 2
+        }
+        throw .decompressionFailed
+    }
+}
+#endif
+
+// MARK: - AvroCodecRegistry
+
+/// A global registry that maps codec names to user-supplied ``CodecProtocol`` implementations.
+///
+/// Register custom codecs at startup before creating any container that uses their names.
+/// Built-in codecs (`null`, `deflate`, `lz4`, `xz`, `lzfse`) are always available
+/// without registration and cannot be overridden.
+///
+/// **Name-based usage:**
+/// ```swift
+/// AvroCodecRegistry.register(ZstdCodec())
+/// let container = try AvroFileObjectContainer(schema: mySchema, codec: ZstdCodec(), syncMarker: marker)
+/// ```
+public enum AvroCodecRegistry {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var registered: [String: any CodecProtocol] = [:]
+
+    /// Registers a codec. Replaces any previous registration under the same name.
+    public static func register(_ codec: any CodecProtocol) {
+        lock.lock(); defer { lock.unlock() }
+        registered[codec.name] = codec
+    }
+
+    /// Looks up a previously registered codec by name. Returns `nil` if not found.
+    public static func codec(named name: String) -> (any CodecProtocol)? {
+        lock.lock(); defer { lock.unlock() }
+        return registered[name]
+    }
+}
+
+// MARK: - CodecFactory
+
+/// Factory that creates ``CodecProtocol`` instances by Avro codec name.
+/// Checks built-in codecs first, then falls back to ``AvroCodecRegistry``.
+enum CodecFactory: Sendable {
+    /// Returns a codec for the given Avro codec name.
+    /// - Throws: ``AvroCodecError/unsupportedCodec(_:)`` if the name is not recognised.
+    static func make(named name: String) throws(AvroCodecError) -> any CodecProtocol {
+        switch name {
+        case AvroReservedConstants.nullCodec:
+            return NullCodec()
+        #if canImport(Compression)
+        case AvroReservedConstants.deflateCodec,
+             AvroReservedConstants.xzCodec,
+             AvroReservedConstants.lz4Codec,
+             AvroReservedConstants.lzfseCodec:
+            return BuiltinCodec(codecName: name)
+        #endif
+        default:
+            if let custom = AvroCodecRegistry.codec(named: name) { return custom }
+            throw .unsupportedCodec(name)
+        }
+    }
+}

--- a/Sources/SwiftAvroRpc/RPC/Channel.swift
+++ b/Sources/SwiftAvroRpc/RPC/Channel.swift
@@ -1,0 +1,44 @@
+//
+//  RPC/Channel.swift
+//  SwiftAvroRpc
+//
+//  Created by Yang Liu on 04/04/2026.
+//  Copyright © 2026 Yang Liu.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import NIO
+
+// MARK: - AvroServerChannel
+
+/// A bound Avro IPC server channel. Returned by ``SwiftAvroRpc/makeServer(host:port:context:serverHash:serverProtocol:handler:)``.
+/// Call ``close()`` to stop accepting connections and release the port.
+public final class AvroServerChannel: Sendable {
+
+    private let channel: any Channel
+
+    init(channel: any Channel) {
+        self.channel = channel
+    }
+
+    /// Closes the server and stops accepting new connections.
+    public func close() async throws {
+        try await channel.close()
+    }
+
+    /// The local address the server is bound to, or nil if unavailable.
+    public var localAddress: String? {
+        channel.localAddress?.description
+    }
+}

--- a/Sources/SwiftAvroRpc/RPC/Client.swift
+++ b/Sources/SwiftAvroRpc/RPC/Client.swift
@@ -1,0 +1,261 @@
+//
+//  RPC/Client.swift
+//  SwiftAvroRpc
+//
+//  Created by Yang Liu on 04/04/2026.
+//
+
+import Foundation
+import NIO
+import SwiftAvroCore
+
+// MARK: - AvroIPCClient
+
+public actor AvroIPCClient {
+
+    private let request:          AvroIPCRequest
+    private var session:          AvroIPCSession
+    private var channel:          (any Channel)?
+    private var pendingCalls:     [PendingCall] = []
+    private var handshakeComplete = false
+    private var serverHash:       MD5Hash
+
+    init(
+        context:        AvroIPCContext,
+        clientHash:     MD5Hash,
+        clientProtocol: String,
+        serverHash:     MD5Hash
+    ) throws {
+        self.session    = AvroIPCSession(context: context)
+        self.request    = try Avro().makeIPCRequest(
+            clientHash:     clientHash,
+            clientProtocol: clientProtocol,
+            session:        session
+        )
+        self.serverHash = serverHash
+    }
+
+    // MARK: - Connection
+
+    func connect(using transport: any AvroIPCClientTransport, eventLoopGroup: EventLoopGroup) async throws {
+        let client = self
+        let bootstrap = ClientBootstrap(group: eventLoopGroup)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelInitializer { channel in
+                do {
+                    try channel.pipeline.syncOperations.addHandler(
+                        ByteToMessageHandler(AvroFrameDecoder())
+                    )
+                    try channel.pipeline.syncOperations.addHandler(
+                        AvroClientChannelHandler(client: client)
+                    )
+                    return channel.eventLoop.makeSucceededVoidFuture()
+                } catch {
+                    return channel.eventLoop.makeFailedFuture(error)
+                }
+            }
+        channel = try await transport.connect(using: bootstrap)
+    }
+
+    public func disconnect() async throws {
+        try await channel?.close()
+        channel = nil
+    }
+
+    // MARK: - Handshake
+
+    /// Two-round-trip handshake: probe → NONE (learn server schema) → retry → BOTH.
+    ///
+    /// After this returns `session.clientCache` holds the server protocol schemas
+    /// and `self.serverHash` is set to the authoritative server hash.
+    private func performHandshake(channel: Channel) async throws {
+        let avro = Avro()
+
+        // Round 1 — initial probe: nil clientProtocol, zero-filled serverHash (per spec).
+        let initialBytes = try request.encodeInitialHandshake(avro: avro, session: session)
+        let resp1Raw: Data = try await withCheckedThrowingContinuation { continuation in
+            pendingCalls.append(PendingCall(messageName: "", continuation: continuation))
+            var buf = channel.allocator.buffer(capacity: initialBytes.count + 8)
+            buf.writeBytes(initialBytes.framing())
+            channel.writeAndFlush(buf, promise: nil)
+        }
+
+        // receive(data:) already deframes; resp1Raw is the raw message bytes.
+        let (resp1, _) = try request.decodeHandshakeResponse(
+            avro: avro, from: resp1Raw, session: session
+        )
+
+        // Update serverHash from any response that carries one.
+        if let newHash = resp1.serverHash { serverHash = newHash }
+
+        // resolveHandshakeResponse updates clientCache and returns retry bytes for NONE,
+        // nil for BOTH or CLIENT (handshake already complete after one round trip).
+        guard let retryBytes = try await request.resolveHandshakeResponse(
+            resp1, avro: avro, session: session
+        ) else {
+            handshakeComplete = true
+            return
+        }
+
+        // Round 2 — retry with full clientProtocol so the server can cache our schema.
+        let resp2Raw: Data = try await withCheckedThrowingContinuation { continuation in
+            pendingCalls.append(PendingCall(messageName: "", continuation: continuation))
+            var buf = channel.allocator.buffer(capacity: retryBytes.count + 8)
+            buf.writeBytes(retryBytes.framing())
+            channel.writeAndFlush(buf, promise: nil)
+        }
+
+        let (resp2, _) = try request.decodeHandshakeResponse(
+            avro: avro, from: resp2Raw, session: session
+        )
+        if let newHash = resp2.serverHash { serverHash = newHash }
+        _ = try await request.resolveHandshakeResponse(resp2, avro: avro, session: session)
+        handshakeComplete = true
+    }
+
+    // MARK: - Two-way RPC call
+
+    /// Sends a typed request and waits for the response.
+    ///
+    /// The Avro IPC handshake is performed automatically on the first call.
+    /// Subsequent calls on the same connection skip the handshake round-trips.
+    public func call<Req: Codable & Sendable, Res: Codable & Sendable>(
+        messageName: String,
+        parameters:  [Req],
+        as responseType: Res.Type
+    ) async throws -> Res {
+        guard let channel else { throw AvroIPCError.connectionClosed }
+
+        if !handshakeComplete {
+            try await performHandshake(channel: channel)
+        }
+
+        let avro = Avro()
+
+        // Every Avro IPC message begins with a HandshakeRequest.
+        let handshakeData = try request.encodeHandshake(
+            avro: avro, serverHash: serverHash, session: session
+        )
+        let callData = try await request.encodeCall(
+            avro:        avro,
+            messageName: messageName,
+            parameters:  parameters,
+            serverHash:  serverHash,
+            session:     session
+        )
+
+        let payload = handshakeData + callData
+        let responseRaw: Data = try await withCheckedThrowingContinuation { continuation in
+            pendingCalls.append(
+                PendingCall(messageName: messageName, continuation: continuation)
+            )
+            var buffer = channel.allocator.buffer(capacity: payload.count + 8)
+            buffer.writeBytes(payload.framing())
+            channel.writeAndFlush(buffer, promise: nil)
+        }
+
+        // responseRaw is already deframed by receive(data:).
+        // Strip the leading HandshakeResponse, then decode the call response.
+        // decodeHandshakeResponse returns data.suffix(...) which is a slice with
+        // non-zero startIndex; copy it so AvroDataReader sees startIndex == 0.
+        let (_, remainingSlice) = try request.decodeHandshakeResponse(
+            avro: avro, from: responseRaw, session: session
+        )
+        let remaining = Data(remainingSlice)
+        let (header, responseArray): (ResponseHeader, [Res]) = try await request.decodeResponse(
+            avro:        avro,
+            messageName: messageName,
+            from:        remaining,
+            serverHash:  serverHash,
+            session:     session
+        )
+
+        if header.flag {
+            let msg = (responseArray.first.map { "\($0)" }) ?? "server error"
+            throw AvroIPCError.serverError(msg)
+        }
+        guard let response = responseArray.first else {
+            throw AvroIPCError.decodingFailed("No response data for '\(messageName)'")
+        }
+        return response
+    }
+
+    // MARK: - One-way RPC call
+
+    /// Sends a one-way (fire-and-forget) request. No response is awaited.
+    ///
+    /// Use for messages declared with `"oneway": true` in the Avro protocol.
+    public func onewayCall<Req: Codable & Sendable>(
+        messageName: String,
+        parameters:  [Req]
+    ) async throws {
+        guard let channel else { throw AvroIPCError.connectionClosed }
+
+        if !handshakeComplete {
+            try await performHandshake(channel: channel)
+        }
+
+        let avro = Avro()
+        let handshakeData = try request.encodeHandshake(
+            avro: avro, serverHash: serverHash, session: session
+        )
+        let callData = try await request.encodeCall(
+            avro:        avro,
+            messageName: messageName,
+            parameters:  parameters,
+            serverHash:  serverHash,
+            session:     session
+        )
+        let payload = handshakeData + callData
+        var buffer = channel.allocator.buffer(capacity: payload.count + 8)
+        buffer.writeBytes(payload.framing())
+        channel.writeAndFlush(buffer, promise: nil)
+    }
+
+    // MARK: - Inbound (NIO handler → actor)
+
+    /// Called by ``AvroClientChannelHandler`` for each complete inbound framed message.
+    ///
+    /// `data` arrives WITH length prefixes from ``AvroFrameDecoder``; deframe here so
+    /// every pending-call continuation receives clean raw message bytes.
+    func receive(data: Data) {
+        guard let pending = pendingCalls.first else { return }
+        pendingCalls.removeFirst()
+        let rawData = data.deFraming().reduce(Data(), +)
+        pending.continuation.resume(returning: rawData)
+    }
+
+    func failAllPending(error: Error) {
+        for pending in pendingCalls {
+            pending.continuation.resume(throwing: error)
+        }
+        pendingCalls.removeAll()
+    }
+}
+
+// MARK: - AvroClientChannelHandler
+
+private final class AvroClientChannelHandler: ChannelInboundHandler, Sendable {
+    typealias InboundIn   = Data
+    typealias OutboundOut = ByteBuffer
+
+    private let client: AvroIPCClient
+
+    init(client: AvroIPCClient) {
+        self.client = client
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let inData = unwrapInboundIn(data)
+        Task { await client.receive(data: inData) }
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        Task { await client.failAllPending(error: AvroIPCError.connectionClosed) }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        Task { await client.failAllPending(error: error) }
+        context.close(promise: nil)
+    }
+}

--- a/Sources/SwiftAvroRpc/RPC/Frame.swift
+++ b/Sources/SwiftAvroRpc/RPC/Frame.swift
@@ -1,0 +1,135 @@
+//
+//  RPC/Frame.swift
+//  SwiftAvroRpc
+//
+//  Created by Yang Liu on 04/04/2026.
+//  Copyright © 2026 Yang Liu.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import NIO
+import SwiftAvroCore
+
+// MARK: - Errors
+
+/// Errors thrown by the Avro IPC client and server.
+enum AvroIPCError: Error, Sendable {
+    /// The handshake exchange failed with the given reason.
+    case handshakeFailed(String)
+    /// Avro encoding of a request or response failed.
+    case encodingFailed(String)
+    /// Avro decoding of a request or response failed.
+    case decodingFailed(String)
+    /// The TCP connection was closed or not established.
+    case connectionClosed
+    /// The operation exceeded the allowed time.
+    case timeout
+    /// No handler was registered for the given message name.
+    case noHandler(String)
+    /// The server returned an error response (flag = true in ResponseHeader).
+    case serverError(String)
+}
+
+// MARK: - AvroIPCHandler
+
+/// Implement this on the server to handle incoming RPC calls.
+public protocol AvroIPCHandler: Sendable {
+    /// Called for each decoded request. Return encoded response data.
+    func handle(messageName: String, requestData: Data) async throws -> Data
+
+    /// Schema-evolution-aware variant. `writerSchemas` are the client's (writer) schemas;
+    /// `readerSchemas` are the server's (reader) schemas for the same message parameters.
+    /// The default implementation ignores schema info and delegates to the basic overload.
+    func handle(
+        messageName:   String,
+        requestData:   Data,
+        writerSchemas: [AvroSchema],
+        readerSchemas: [AvroSchema]
+    ) async throws -> Data
+}
+
+extension AvroIPCHandler {
+    public func handle(
+        messageName:   String,
+        requestData:   Data,
+        writerSchemas: [AvroSchema],
+        readerSchemas: [AvroSchema]
+    ) async throws -> Data {
+        try await handle(messageName: messageName, requestData: requestData)
+    }
+}
+
+// MARK: - Pending call (client side)
+
+/// A suspended RPC call waiting for the server's response.
+struct PendingCall: Sendable {
+    let messageName: String
+    let continuation: CheckedContinuation<Data, Error>
+}
+
+// MARK: - AvroFrameDecoder
+
+/// NIO decoder that accumulates length-prefixed Avro frames until the
+/// zero-length terminator, then fires a single channel read event with
+/// the complete reassembled framed message (including all length prefixes
+/// and the terminator). This ensures each handler receives exactly one
+/// event per complete Avro IPC message, so deFraming() works correctly
+/// downstream and pendingCalls is consumed exactly once per round-trip.
+final class AvroFrameDecoder: ByteToMessageDecoder {
+    typealias InboundOut = Data
+
+    func decode(
+        context: ChannelHandlerContext,
+        buffer: inout ByteBuffer
+    ) throws -> DecodingState {
+        // Scan ahead to find the zero-length terminator without consuming bytes.
+        // Only read once the full message including terminator is in the buffer.
+        var scanIndex = buffer.readerIndex
+        var totalSize = 0
+
+        while scanIndex + 4 <= buffer.writerIndex {
+            guard let length = buffer.getInteger(
+                at: scanIndex, as: UInt32.self
+            ) else { return .needMoreData }
+
+            totalSize += 4
+            scanIndex += 4
+
+            if length == 0 {
+                // Terminator found — read the entire message as one Data.
+                guard let bytes = buffer.readBytes(length: totalSize) else {
+                    return .needMoreData
+                }
+                context.fireChannelRead(wrapInboundOut(Data(bytes)))
+                return .continue
+            }
+
+            let payloadSize = Int(length)
+            guard scanIndex + payloadSize <= buffer.writerIndex else {
+                return .needMoreData
+            }
+            totalSize += payloadSize
+            scanIndex += payloadSize
+        }
+        return .needMoreData
+    }
+
+    func decodeLast(
+        context: ChannelHandlerContext,
+        buffer: inout ByteBuffer,
+        seenEOF: Bool
+    ) throws -> DecodingState {
+        try decode(context: context, buffer: &buffer)
+    }
+}

--- a/Sources/SwiftAvroRpc/RPC/HTTPClient.swift
+++ b/Sources/SwiftAvroRpc/RPC/HTTPClient.swift
@@ -1,0 +1,287 @@
+//
+//  RPC/HTTPClient.swift
+//  SwiftAvroRpc
+//
+//  Created by Yang Liu on 09/05/2026.
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOSSL
+import SwiftAvroCore
+
+// MARK: - AvroIPCHTTPClient
+
+/// An Avro IPC client that sends each call as an HTTP POST.
+///
+/// Unlike the TCP client, each call opens a fresh connection, so no explicit
+/// `disconnect()` is needed. The Avro IPC handshake is performed transparently
+/// on the first call; subsequent calls reuse the accumulated session state.
+///
+/// Obtain an instance via ``SwiftAvroRpc/makeHTTPClient(_:)``.
+public actor AvroIPCHTTPClient {
+
+    private let request:          AvroIPCRequest
+    private var session:          AvroIPCSession
+    private var handshakeComplete = false
+    private var serverHash:       MD5Hash
+
+    private let host:           String
+    private let port:           Int
+    private let path:           String
+    private let eventLoopGroup: EventLoopGroup
+    private let tlsContext:     NIOSSLContext?
+
+    // MARK: - Init
+
+    init(
+        context:        AvroIPCContext,
+        clientHash:     MD5Hash,
+        clientProtocol: String,
+        serverHash:     MD5Hash,
+        host:           String,
+        port:           Int,
+        path:           String,
+        eventLoopGroup: EventLoopGroup,
+        tlsContext:     NIOSSLContext? = nil
+    ) throws {
+        self.session    = AvroIPCSession(context: context)
+        self.request    = try Avro().makeIPCRequest(
+            clientHash:     clientHash,
+            clientProtocol: clientProtocol,
+            session:        session
+        )
+        self.serverHash     = serverHash
+        self.host           = host
+        self.port           = port
+        self.path           = path
+        self.eventLoopGroup = eventLoopGroup
+        self.tlsContext     = tlsContext
+    }
+
+    // MARK: - HTTP POST
+
+    /// Opens a new HTTP(S) connection, POSTs `body`, returns the complete response body.
+    private func post(body: Data) async throws -> Data {
+        let host = self.host
+        let port = self.port
+        let path = self.path
+        let tls  = self.tlsContext
+        let elg  = self.eventLoopGroup
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let handler = AvroHTTPClientHandler(continuation: continuation)
+
+            ClientBootstrap(group: elg)
+                .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .channelInitializer { channel in
+                    do {
+                        if let tls {
+                            let ssl = try NIOSSLClientHandler(context: tls, serverHostname: host)
+                            try channel.pipeline.syncOperations.addHandler(ssl)
+                        }
+                        try channel.pipeline.syncOperations.addHandlers(
+                            HTTPRequestEncoder(),
+                            ByteToMessageHandler(HTTPResponseDecoder()),
+                            handler
+                        )
+                        return channel.eventLoop.makeSucceededVoidFuture()
+                    } catch {
+                        return channel.eventLoop.makeFailedFuture(error)
+                    }
+                }
+                .connect(host: host, port: port)
+                .whenComplete { result in
+                    switch result {
+                    case .failure(let error):
+                        // Pipeline was never set up; resume the continuation directly.
+                        handler.fail(error)
+                    case .success(let channel):
+                        var headers = HTTPHeaders()
+                        headers.add(name: "Host",           value: host)
+                        headers.add(name: "Content-Type",   value: "avro/binary")
+                        headers.add(name: "Content-Length", value: "\(body.count)")
+                        headers.add(name: "Connection",     value: "close")
+                        let head = HTTPRequestHead(
+                            version: .http1_1,
+                            method:  .POST,
+                            uri:     path,
+                            headers: headers
+                        )
+                        channel.write(HTTPClientRequestPart.head(head), promise: nil)
+                        var buf = channel.allocator.buffer(capacity: body.count)
+                        buf.writeBytes(body)
+                        channel.write(HTTPClientRequestPart.body(.byteBuffer(buf)), promise: nil)
+                        channel.writeAndFlush(HTTPClientRequestPart.end(nil), promise: nil)
+                    }
+                }
+        }
+    }
+
+    // MARK: - Payload builder
+
+    /// Encodes the handshake prefix + call body into one `Data` ready for framing.
+    private func buildPayload<Req: Codable & Sendable>(
+        messageName: String,
+        parameters:  [Req]
+    ) async throws -> Data {
+        let avro = Avro()
+        let handshakeData = try request.encodeHandshake(
+            avro: avro, serverHash: serverHash, session: session
+        )
+        let callData = try await request.encodeCall(
+            avro:        avro,
+            messageName: messageName,
+            parameters:  parameters,
+            serverHash:  serverHash,
+            session:     session
+        )
+        return handshakeData + callData
+    }
+
+    // MARK: - Handshake
+
+    /// Two-round-trip IPC handshake over HTTP POST.
+    private func performHandshake() async throws {
+        let avro = Avro()
+
+        // Round 1 — initial probe.
+        let initialBytes = try request.encodeInitialHandshake(avro: avro, session: session)
+        let resp1Msg = try await post(body: initialBytes.framing()).deFramed()
+
+        let (resp1, _) = try request.decodeHandshakeResponse(
+            avro: avro, from: resp1Msg, session: session
+        )
+        if let newHash = resp1.serverHash { serverHash = newHash }
+
+        guard let retryBytes = try await request.resolveHandshakeResponse(
+            resp1, avro: avro, session: session
+        ) else {
+            handshakeComplete = true
+            return
+        }
+
+        // Round 2 — retry with full client protocol.
+        let resp2Msg = try await post(body: retryBytes.framing()).deFramed()
+
+        let (resp2, _) = try request.decodeHandshakeResponse(
+            avro: avro, from: resp2Msg, session: session
+        )
+        if let newHash = resp2.serverHash { serverHash = newHash }
+        _ = try await request.resolveHandshakeResponse(resp2, avro: avro, session: session)
+        handshakeComplete = true
+    }
+
+    // MARK: - Two-way call
+
+    /// Sends a typed request and waits for the response.
+    ///
+    /// The IPC handshake is performed automatically on the first call.
+    public func call<Req: Codable & Sendable, Res: Codable & Sendable>(
+        messageName: String,
+        parameters:  [Req],
+        as responseType: Res.Type
+    ) async throws -> Res {
+        if !handshakeComplete {
+            try await performHandshake()
+        }
+
+        let payload      = try await buildPayload(messageName: messageName, parameters: parameters)
+        let avro         = Avro()
+        let responseMsg  = try await post(body: payload.framing()).deFramed()
+
+        let (_, remainingSlice) = try request.decodeHandshakeResponse(
+            avro: avro, from: responseMsg, session: session
+        )
+        let remaining = Data(remainingSlice)
+        let (header, responseArray): (ResponseHeader, [Res]) = try await request.decodeResponse(
+            avro:        avro,
+            messageName: messageName,
+            from:        remaining,
+            serverHash:  serverHash,
+            session:     session
+        )
+
+        if header.flag {
+            let msg = (responseArray.first.map { "\($0)" }) ?? "server error"
+            throw AvroIPCError.serverError(msg)
+        }
+        guard let result = responseArray.first else {
+            throw AvroIPCError.decodingFailed("No response data for '\(messageName)'")
+        }
+        return result
+    }
+
+    // MARK: - One-way call
+
+    /// Sends a one-way (fire-and-forget) request over HTTP POST.
+    ///
+    /// The HTTP response is awaited so the caller can detect transport errors,
+    /// but the Avro response body (which contains only a HandshakeResponse) is discarded.
+    public func onewayCall<Req: Codable & Sendable>(
+        messageName: String,
+        parameters:  [Req]
+    ) async throws {
+        if !handshakeComplete {
+            try await performHandshake()
+        }
+        let payload = try await buildPayload(messageName: messageName, parameters: parameters)
+        _ = try await post(body: payload.framing())
+    }
+}
+
+// MARK: - AvroHTTPClientHandler
+
+/// NIO channel handler that accumulates the HTTP response body and resumes
+/// the `CheckedContinuation` when the response is complete.
+///
+/// All mutable state is accessed only on the channel's event loop — safe with `@unchecked Sendable`.
+private final class AvroHTTPClientHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn   = HTTPClientResponsePart
+    typealias OutboundOut = Never
+
+    private static let maxBodyBytes = 64 * 1024 * 1024   // 64 MB
+
+    private let continuation:   CheckedContinuation<Data, Error>
+    private var bodyAccumulator = Data()
+    private var resumed         = false
+
+    init(continuation: CheckedContinuation<Data, Error>) {
+        self.continuation = continuation
+    }
+
+    /// Called when the connection fails before any pipeline events fire.
+    func fail(_ error: Error) {
+        guard !resumed else { return }
+        resumed = true
+        continuation.resume(throwing: error)
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch unwrapInboundIn(data) {
+        case .head:
+            bodyAccumulator = Data()
+        case .body(var buffer):
+            guard bodyAccumulator.count + buffer.readableBytes <= Self.maxBodyBytes else {
+                context.close(promise: nil)
+                return
+            }
+            if let bytes = buffer.readBytes(length: buffer.readableBytes) {
+                bodyAccumulator.append(contentsOf: bytes)
+            }
+        case .end:
+            guard !resumed else { return }
+            resumed = true
+            continuation.resume(returning: bodyAccumulator)
+            context.close(promise: nil)
+        }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        guard !resumed else { return }
+        resumed = true
+        continuation.resume(throwing: error)
+        context.close(promise: nil)
+    }
+}

--- a/Sources/SwiftAvroRpc/RPC/HTTPServer.swift
+++ b/Sources/SwiftAvroRpc/RPC/HTTPServer.swift
@@ -1,0 +1,159 @@
+//
+//  RPC/HTTPServer.swift
+//  SwiftAvroRpc
+//
+//  Created by Yang Liu on 09/05/2026.
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOSSL
+import SwiftAvroCore
+
+// MARK: - AvroIPCHTTPServerBootstrap
+
+/// Binds an HTTP (or HTTPS) server and routes each POST body through a shared
+/// ``AvroIPCServer`` actor. Sharing a single actor across all connections means
+/// the server-side session cache (client protocol registry) persists for the
+/// lifetime of the server — enabling BOTH-match handshakes on subsequent calls.
+final class AvroIPCHTTPServerBootstrap: Sendable {
+
+    private let eventLoopGroup: EventLoopGroup
+    private let context:        AvroIPCContext
+    private let serverHash:     MD5Hash
+    private let serverProtocol: String
+    private let handler:        any AvroIPCHandler
+    private let tlsContext:     NIOSSLContext?
+
+    init(
+        eventLoopGroup: EventLoopGroup,
+        context:        AvroIPCContext,
+        serverHash:     MD5Hash,
+        serverProtocol: String,
+        handler:        any AvroIPCHandler,
+        tlsContext:     NIOSSLContext? = nil
+    ) {
+        self.eventLoopGroup  = eventLoopGroup
+        self.context         = context
+        self.serverHash      = serverHash
+        self.serverProtocol  = serverProtocol
+        self.handler         = handler
+        self.tlsContext      = tlsContext
+    }
+
+    func bind(host: String, port: Int) async throws -> Channel {
+        // One shared IPC server for all HTTP connections: the session cache accumulates
+        // client protocols across requests so re-negotiation is avoided after first contact.
+        let ipcServer = AvroIPCServer(
+            context:        context,
+            serverHash:     serverHash,
+            serverProtocol: serverProtocol,
+            handler:        handler
+        )
+        let tls = self.tlsContext
+
+        return try await ServerBootstrap(group: eventLoopGroup)
+            .serverChannelOption(ChannelOptions.backlog, value: 256)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                do {
+                    if let tls {
+                        let sslHandler = NIOSSLServerHandler(context: tls)
+                        try channel.pipeline.syncOperations.addHandler(sslHandler)
+                    }
+                    try channel.pipeline.syncOperations.addHandlers(
+                        HTTPResponseEncoder(),
+                        ByteToMessageHandler(HTTPRequestDecoder()),
+                        AvroHTTPServerHandler(ipcServer: ipcServer)
+                    )
+                    return channel.eventLoop.makeSucceededVoidFuture()
+                } catch {
+                    return channel.eventLoop.makeFailedFuture(error)
+                }
+            }
+            .bind(host: host, port: port)
+            .get()
+    }
+}
+
+// MARK: - AvroHTTPServerHandler
+
+/// NIO channel handler that accumulates the HTTP request body and dispatches it to
+/// ``AvroIPCServer/receive(data:)``. The Avro IPC framing (length-prefixed frames)
+/// is preserved inside the HTTP body, matching the Avro HTTP transport specification.
+private final class AvroHTTPServerHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn   = HTTPServerRequestPart
+    typealias OutboundOut = HTTPServerResponsePart
+
+    private static let maxBodyBytes = 64 * 1024 * 1024   // 64 MB
+
+    private let ipcServer: AvroIPCServer
+    // Accessed only on the channel's event loop — safe without additional locking.
+    private var bodyAccumulator = Data()
+    private var keepAlive       = true
+
+    init(ipcServer: AvroIPCServer) {
+        self.ipcServer = ipcServer
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch unwrapInboundIn(data) {
+        case .head(let head):
+            bodyAccumulator = Data()
+            keepAlive       = head.isKeepAlive
+        case .body(var buffer):
+            guard bodyAccumulator.count + buffer.readableBytes <= Self.maxBodyBytes else {
+                context.close(promise: nil)
+                return
+            }
+            if let bytes = buffer.readBytes(length: buffer.readableBytes) {
+                bodyAccumulator.append(contentsOf: bytes)
+            }
+        case .end:
+            let requestData = bodyAccumulator
+            let keepAlive   = self.keepAlive
+            let channel     = context.channel
+            let server      = ipcServer
+            Task {
+                do {
+                    let responseData = try await server.receive(data: requestData)
+                    Self.write(responseData, status: .ok, to: channel, keepAlive: keepAlive)
+                } catch {
+                    // Send the zero-length frame terminator so the client's deframing
+                    // layer gets a valid (empty) Avro message instead of raw empty bytes.
+                    Self.write(Data([0, 0, 0, 0]), status: .internalServerError,
+                               to: channel, keepAlive: false)
+                }
+            }
+        }
+    }
+
+    private static func write(
+        _ body:      Data,
+        status:      HTTPResponseStatus,
+        to channel:  Channel,
+        keepAlive:   Bool
+    ) {
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type",   value: "avro/binary")
+        headers.add(name: "Content-Length", value: "\(body.count)")
+        if !keepAlive { headers.add(name: "Connection", value: "close") }
+
+        channel.write(HTTPServerResponsePart.head(
+            HTTPResponseHead(version: .http1_1, status: status, headers: headers)
+        ), promise: nil)
+
+        if !body.isEmpty {
+            var buf = channel.allocator.buffer(capacity: body.count)
+            buf.writeBytes(body)
+            channel.write(HTTPServerResponsePart.body(.byteBuffer(buf)), promise: nil)
+        }
+        channel.writeAndFlush(HTTPServerResponsePart.end(nil), promise: nil)
+        if !keepAlive { channel.close(promise: nil) }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        context.close(promise: nil)
+    }
+}

--- a/Sources/SwiftAvroRpc/RPC/Server.swift
+++ b/Sources/SwiftAvroRpc/RPC/Server.swift
@@ -1,0 +1,231 @@
+//
+//  RPC/Server.swift
+//  SwiftAvroRpc
+//
+//  Created by Yang Liu on 04/04/2026.
+//  Copyright © 2026 Yang Liu.
+//
+
+import Foundation
+import NIO
+import SwiftAvroCore
+
+// MARK: - AvroIPCServer
+
+/// Actor that owns the server-side handshake state and dispatches decoded
+/// requests to the application-level ``AvroIPCHandler``.
+///
+/// One instance is created per accepted TCP connection; state is never shared
+/// between connections.
+public actor AvroIPCServer {
+
+    private let response:       AvroIPCResponse
+    private var session:        AvroIPCSession
+    private let handler:        any AvroIPCHandler
+    private var avroProtocol:   AvroProtocol?   // lazily parsed from response.serverProtocol
+
+    /// Creates a server instance for a single connection.
+    init(
+        context:        AvroIPCContext,
+        serverHash:     MD5Hash,
+        serverProtocol: String,
+        handler:        any AvroIPCHandler
+    ) {
+        self.response = Avro().makeIPCResponse(
+            serverHash:     serverHash,
+            serverProtocol: serverProtocol
+        )
+        self.session  = AvroIPCSession(context: context)
+        self.handler  = handler
+    }
+
+    /// Returns true if the named message is declared one-way in the server protocol.
+    private func isOneway(_ messageName: String) -> Bool {
+        if avroProtocol == nil {
+            avroProtocol = try? JSONDecoder().decode(
+                AvroProtocol.self,
+                from: Data(response.serverProtocol.utf8)
+            )
+        }
+        return avroProtocol?.messages?[messageName]?.oneway == true
+    }
+
+    // MARK: - Inbound
+
+    /// Processes one complete inbound Avro IPC framed message and returns the
+    /// framed response to write back to the channel.
+    func receive(data: Data) async throws -> Data {
+        let avro = Avro()
+
+        // AvroFrameDecoder fires the raw framed bytes (WITH length prefixes).
+        // Deframe them and join all frame payloads into one message buffer.
+        let frames = data.deFraming()
+        guard !frames.isEmpty else {
+            throw AvroIPCError.decodingFailed("Empty frame")
+        }
+        let messageData = frames.reduce(Data(), +)
+
+        // Resolve handshake: updates session.serverCache, returns the
+        // serialised HandshakeResponse and the remaining call payload.
+        let (handshakeReq, handshakeResponseData, callPayload) =
+            try await response.resolveHandshake(avro: avro, from: messageData, session: session)
+
+        // Pure handshake exchange — no call payload (e.g. the initial probe or retry).
+        guard !callPayload.isEmpty else {
+            return handshakeResponseData.framing()
+        }
+
+        // Read meta + message name from the call payload to build RequestHeader.
+        // We use AvroDataReader directly so we never pass pre-encoded Data into
+        // the typed encodeResponse<T:Codable> path (which would double-encode it).
+        let stringSchema = avro.newSchema(schema: "\"string\"")!
+        let reader       = avro.makeDataReader(data: callPayload)
+        let meta: [String: [UInt8]] = try reader.decode(schema: session.context.metaSchema)
+        let messageName: String     = try reader.decode(schema: stringSchema)
+        let paramsOffset = callPayload.count - reader.bytesRemaining
+        let paramsData   = Data(callPayload.dropFirst(paramsOffset))
+
+        // Fetch writer (client) and reader (server) request schemas for evolution.
+        // isOneway() also lazily populates avroProtocol, so call it first.
+        let oneway = isOneway(messageName)
+        let writerSchemas = await session.serverCache.requestSchemas(
+            hash: handshakeReq.clientHash, messageName: messageName
+        ) ?? []
+        let readerSchemas = avroProtocol?.getRequest(messageName: messageName) ?? []
+
+        // One-way messages: dispatch handler but do not send a call response.
+        // The framed HandshakeResponse is still sent so the peer's session stays in sync.
+        if oneway {
+            _ = try? await handler.handle(
+                messageName:   messageName,
+                requestData:   paramsData,
+                writerSchemas: writerSchemas,
+                readerSchemas: readerSchemas
+            )
+            return handshakeResponseData.framing()
+        }
+
+        // Two-way call: dispatch handler, encode result (or error) as response payload:
+        // meta + flag(bool) + body.
+        let boolSchema = avro.newSchema(schema: "\"boolean\"")!
+
+        do {
+            let responseBody = try await handler.handle(
+                messageName:   messageName,
+                requestData:   paramsData,
+                writerSchemas: writerSchemas,
+                readerSchemas: readerSchemas
+            )
+            var payload = Data()
+            payload.append(try avro.encodeFrom(meta, schema: session.context.metaSchema))
+            payload.append(try avro.encodeFrom(false, schema: boolSchema))
+            payload.append(responseBody)
+            return (handshakeResponseData + payload).framing()
+
+        } catch {
+            // Avro IPC error response: flag=true + union-index 0 (undeclared string error).
+            var payload = Data()
+            payload.append(try avro.encodeFrom(meta, schema: session.context.metaSchema))
+            payload.append(try avro.encodeFrom(true, schema: boolSchema))
+            payload.append(contentsOf: [UInt8(0)])   // zig-zag 0 = union branch 0 (string)
+            payload.append(try avro.encodeFrom(
+                error.localizedDescription, schema: stringSchema
+            ))
+            return (handshakeResponseData + payload).framing()
+        }
+    }
+}
+
+// MARK: - AvroIPCServerBootstrap
+
+/// Starts the NIO server and creates an ``AvroIPCServer`` per accepted channel.
+final class AvroIPCServerBootstrap: Sendable {
+
+    private let eventLoopGroup: EventLoopGroup
+    private let context:        AvroIPCContext
+    private let serverHash:     MD5Hash
+    private let serverProtocol: String
+    private let handler:        any AvroIPCHandler
+
+    init(
+        eventLoopGroup: EventLoopGroup,
+        context:        AvroIPCContext,
+        serverHash:     MD5Hash,
+        serverProtocol: String,
+        handler:        any AvroIPCHandler
+    ) {
+        self.eventLoopGroup  = eventLoopGroup
+        self.context         = context
+        self.serverHash      = serverHash
+        self.serverProtocol  = serverProtocol
+        self.handler         = handler
+    }
+
+    /// Binds using the given transport (TCP, Unix domain socket, or custom).
+    func bind(using transport: any AvroIPCServerTransport) async throws -> any Channel {
+        try await transport.bind(using: makeBootstrap())
+    }
+
+    private func makeBootstrap() -> ServerBootstrap {
+        let context        = self.context
+        let serverHash     = self.serverHash
+        let serverProtocol = self.serverProtocol
+        let handler        = self.handler
+
+        return ServerBootstrap(group: eventLoopGroup)
+            .serverChannelOption(ChannelOptions.backlog, value: 256)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                let server = AvroIPCServer(
+                    context:        context,
+                    serverHash:     serverHash,
+                    serverProtocol: serverProtocol,
+                    handler:        handler
+                )
+                do {
+                    try channel.pipeline.syncOperations.addHandler(
+                        ByteToMessageHandler(AvroFrameDecoder())
+                    )
+                    try channel.pipeline.syncOperations.addHandler(
+                        AvroServerChannelHandler(server: server)
+                    )
+                    return channel.eventLoop.makeSucceededVoidFuture()
+                } catch {
+                    return channel.eventLoop.makeFailedFuture(error)
+                }
+            }
+    }
+}
+
+// MARK: - AvroServerChannelHandler
+
+private final class AvroServerChannelHandler: ChannelInboundHandler, Sendable {
+    typealias InboundIn   = Data
+    typealias OutboundOut = ByteBuffer
+
+    private let server: AvroIPCServer
+
+    init(server: AvroIPCServer) {
+        self.server = server
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let inData  = unwrapInboundIn(data)
+        let channel = context.channel
+        Task {
+            do {
+                let responseData = try await server.receive(data: inData)
+                var buffer = channel.allocator.buffer(capacity: responseData.count)
+                buffer.writeBytes(responseData)
+                channel.writeAndFlush(buffer, promise: nil)
+            } catch {
+                // Protocol-level decode failure: close the connection.
+                channel.close(promise: nil)
+            }
+        }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        context.close(promise: nil)
+    }
+}

--- a/Sources/SwiftAvroRpc/RPC/Transport.swift
+++ b/Sources/SwiftAvroRpc/RPC/Transport.swift
@@ -1,0 +1,44 @@
+//
+//  RPC/Transport.swift
+//  SwiftAvroRpc
+//
+//  Created by Yang Liu on 11/05/2026.
+//
+
+import NIO
+
+// MARK: - Transport protocols
+
+/// Abstracts how a server binds to a local address.
+/// Implement this protocol to support custom transports (e.g. Unix domain sockets).
+public protocol AvroIPCServerTransport: Sendable {
+    func bind(using bootstrap: ServerBootstrap) async throws -> any Channel
+}
+
+/// Abstracts how a client connects to a remote address.
+/// Implement this protocol to support custom transports (e.g. Unix domain sockets).
+public protocol AvroIPCClientTransport: Sendable {
+    func connect(using bootstrap: ClientBootstrap) async throws -> any Channel
+}
+
+// MARK: - Built-in TCP transport
+
+/// Standard TCP transport. The default when no custom transport is required.
+public struct TCPTransport: AvroIPCServerTransport, AvroIPCClientTransport {
+
+    public let host: String
+    public let port: Int
+
+    public init(host: String = "0.0.0.0", port: Int) {
+        self.host = host
+        self.port = port
+    }
+
+    public func bind(using bootstrap: ServerBootstrap) async throws -> any Channel {
+        try await bootstrap.bind(host: host, port: port).get()
+    }
+
+    public func connect(using bootstrap: ClientBootstrap) async throws -> any Channel {
+        try await bootstrap.connect(host: host, port: port).get()
+    }
+}

--- a/Sources/SwiftAvroRpc/SwiftAvroRpc.swift
+++ b/Sources/SwiftAvroRpc/SwiftAvroRpc.swift
@@ -1,0 +1,419 @@
+//
+//  SwiftAvroRpc.swift
+//  SwiftAvroRpc
+//
+//  Created by Yang Liu on 06/04/2026.
+//
+
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import Crypto
+#endif
+import Foundation
+import SwiftAvroCore
+@preconcurrency import NIO
+import NIOSSL
+
+// MARK: - AvroTLSConfig
+
+/// Wraps an `NIOSSLContext` for optional TLS on HTTP servers and clients.
+///
+/// Pass an `AvroTLSConfig` to ``AvroIPCHTTPServerConfig`` or ``AvroIPCHTTPClientConfig``
+/// to upgrade a plain-HTTP transport to HTTPS. Omit it (leave `nil`) for plain HTTP.
+public struct AvroTLSConfig: @unchecked Sendable {
+    let sslContext: NIOSSLContext
+
+    init(sslContext: NIOSSLContext) { self.sslContext = sslContext }
+
+    /// TLS for an HTTPS **client** using the system trust store.
+    public static func client() throws -> AvroTLSConfig {
+        try .init(sslContext: NIOSSLContext(configuration: .makeClientConfiguration()))
+    }
+
+    /// TLS for an HTTPS **server** with a PEM certificate and private key.
+    /// - Parameters:
+    ///   - certificateFile: Path to the PEM certificate chain file.
+    ///   - privateKeyFile:  Path to the PEM private key file.
+    public static func server(
+        certificateFile: String,
+        privateKeyFile:  String
+    ) throws -> AvroTLSConfig {
+        let certs = try NIOSSLCertificate.fromPEMFile(certificateFile)
+        let key   = try NIOSSLPrivateKey(file: privateKeyFile, format: .pem)
+        let cfg   = TLSConfiguration.makeServerConfiguration(
+            certificateChain: certs.map { .certificate($0) },
+            privateKey:       .privateKey(key)
+        )
+        return try .init(sslContext: NIOSSLContext(configuration: cfg))
+    }
+}
+
+// MARK: - AvroIPCHTTPServerConfig
+
+/// Configuration for an Avro IPC server that speaks HTTP (or HTTPS).
+public struct AvroIPCHTTPServerConfig: Sendable {
+    public let host:           String
+    public let port:           Int
+    /// URL path the server listens on. Defaults to `"/"`.
+    public let path:           String
+    public let context:        AvroIPCContext
+    public let serverHash:     MD5Hash
+    public let serverProtocol: String
+    public let handler:        any AvroIPCHandler
+    /// Non-nil enables TLS (HTTPS). `nil` runs plain HTTP.
+    public let tls:            AvroTLSConfig?
+
+    public init(
+        host:           String = "0.0.0.0",
+        port:           Int,
+        path:           String = "/",
+        context:        AvroIPCContext,
+        serverHash:     MD5Hash,
+        serverProtocol: String,
+        handler:        any AvroIPCHandler,
+        tls:            AvroTLSConfig? = nil
+    ) {
+        self.host           = host
+        self.port           = port
+        self.path           = path
+        self.context        = context
+        self.serverHash     = serverHash
+        self.serverProtocol = serverProtocol
+        self.handler        = handler
+        self.tls            = tls
+    }
+}
+
+// MARK: - AvroIPCHTTPClientConfig
+
+/// Configuration for an Avro IPC client that speaks HTTP (or HTTPS).
+public struct AvroIPCHTTPClientConfig: Sendable {
+    public let host:           String
+    public let port:           Int
+    /// URL path to POST to. Defaults to `"/"`.
+    public let path:           String
+    public let context:        AvroIPCContext
+    public let clientHash:     MD5Hash
+    public let clientProtocol: String
+    public let serverHash:     MD5Hash
+    /// Non-nil enables TLS (HTTPS). `nil` runs plain HTTP.
+    public let tls:            AvroTLSConfig?
+
+    public init(
+        host:           String,
+        port:           Int,
+        path:           String = "/",
+        context:        AvroIPCContext,
+        clientHash:     MD5Hash,
+        clientProtocol: String,
+        serverHash:     MD5Hash,
+        tls:            AvroTLSConfig? = nil
+    ) {
+        self.host           = host
+        self.port           = port
+        self.path           = path
+        self.context        = context
+        self.clientHash     = clientHash
+        self.clientProtocol = clientProtocol
+        self.serverHash     = serverHash
+        self.tls            = tls
+    }
+}
+
+// MARK: - AvroIPCServerConfig
+
+/// Configuration for an Avro IPC server.
+///
+/// Pass any ``AvroIPCServerTransport`` as `transport` — use ``TCPTransport`` for
+/// standard TCP or supply a custom implementation (e.g. Unix domain socket) from
+/// the call site.
+public struct AvroIPCServerConfig: Sendable {
+
+    /// Determines how the server binds to a local address.
+    public let transport: any AvroIPCServerTransport
+
+    /// The shared IPC context holding pre-parsed handshake schemas and metadata.
+    public let context: AvroIPCContext
+
+    /// The 16-byte MD5 hash identifying this server's protocol.
+    public let serverHash: MD5Hash
+
+    /// The Avro protocol JSON string this server implements.
+    public let serverProtocol: String
+
+    /// The application-level handler that processes incoming RPC calls.
+    public let handler: any AvroIPCHandler
+
+    public init(
+        transport: any AvroIPCServerTransport,
+        context: AvroIPCContext,
+        serverHash: MD5Hash,
+        serverProtocol: String,
+        handler: any AvroIPCHandler
+    ) {
+        self.transport      = transport
+        self.context        = context
+        self.serverHash     = serverHash
+        self.serverProtocol = serverProtocol
+        self.handler        = handler
+    }
+}
+
+// MARK: - AvroIPCClientConfig
+
+/// Configuration for an Avro IPC client.
+///
+/// Pass any ``AvroIPCClientTransport`` as `transport` — use ``TCPTransport`` for
+/// standard TCP or supply a custom implementation (e.g. Unix domain socket) from
+/// the call site.
+public struct AvroIPCClientConfig: Sendable {
+
+    /// Determines how the client connects to the remote address.
+    public let transport: any AvroIPCClientTransport
+
+    /// The shared IPC context holding pre-parsed handshake schemas and metadata.
+    public let context: AvroIPCContext
+
+    /// The 16-byte MD5 hash identifying this client's protocol.
+    public let clientHash: MD5Hash
+
+    /// The Avro protocol JSON string this client speaks.
+    public let clientProtocol: String
+
+    /// The expected 16-byte MD5 hash of the server's protocol.
+    public let serverHash: MD5Hash
+
+    public init(
+        transport: any AvroIPCClientTransport,
+        context: AvroIPCContext,
+        clientHash: MD5Hash,
+        clientProtocol: String,
+        serverHash: MD5Hash
+    ) {
+        self.transport      = transport
+        self.context        = context
+        self.clientHash     = clientHash
+        self.clientProtocol = clientProtocol
+        self.serverHash     = serverHash
+    }
+}
+
+// MARK: - SwiftAvroRpc
+
+/// The main entry point for the SwiftAvroRpc package.
+///
+/// `SwiftAvroRpc` is an actor that manages the NIO event loop group and acts as
+/// a factory for object container files, IPC servers, and IPC clients. Its actor
+/// isolation ensures that the event loop group lifecycle — start and stop — is
+/// never accessed concurrently.
+///
+/// Typical lifecycle:
+///
+///     let rpc    = SwiftAvroRpc()
+///     let server = try await rpc.makeServer(serverConfig)
+///     let client = try await rpc.makeClient(clientConfig)
+///     // ... use client and server ...
+///     try await client.disconnect()
+///     try await server.close()
+///     await rpc.stop()
+public actor SwiftAvroRpc {
+
+    // MARK: - State
+
+    private enum State {
+        case running
+        case stopped
+    }
+
+    private let eventLoopGroup: MultiThreadedEventLoopGroup
+    private var state: State = .running
+
+    // MARK: - Init
+
+    /// Creates a `SwiftAvroRpc` actor with a managed NIO event loop group.
+    /// The group starts immediately and runs until ``stop()`` is called.
+    /// - Parameter threads: Number of event loop threads. Defaults to the number of CPU cores.
+    public init(threads: Int = System.coreCount) {
+        self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: threads)
+    }
+
+    // MARK: - Object Container File
+
+    /// Creates an ``AvroFileObjectContainer`` actor for reading and writing Avro container files.
+    ///
+    /// The container is safe to use from concurrent Swift code — all read and write
+    /// operations are actor-isolated. Supported codecs are `null`, `deflate`, `xz`,
+    /// `lz4`, and `lzfse`.
+    ///
+    /// - Parameters:
+    ///   - schema: A valid Avro JSON schema string describing the record type.
+    ///   - codecName: The compression codec to use. Defaults to `null` (no compression).
+    ///   - syncMarker: 16-byte sync marker for the container. Required for writing.
+    /// - Throws: ``AvroContainerError`` if the schema is invalid or the codec is unsupported.
+    /// - Returns: A ready-to-use container actor.
+    public func makeContainer(
+        schema: String,
+        codecName: String = AvroReservedConstants.nullCodec,
+        syncMarker: [UInt8] = (0..<16).map { _ in UInt8.random(in: 0...255) }
+    ) throws -> AvroFileObjectContainer {
+        try guardRunning()
+        let codec = try CodecFactory.make(named: codecName)
+        return try AvroFileObjectContainer(schema: schema, codec: codec, syncMarker: syncMarker)
+    }
+
+    // MARK: - IPC Context
+
+    /// Creates an ``AvroIPCContext`` that holds pre-parsed handshake schemas and metadata.
+    ///
+    /// The context is immutable and shared across the client and server for the lifetime
+    /// of the application. Pass it into ``AvroIPCServerConfig`` or ``AvroIPCClientConfig``.
+    ///
+    /// - Parameters:
+    ///   - requestMeta: Metadata to include in outgoing handshake requests.
+    ///   - responseMeta: Metadata to include in outgoing handshake responses.
+    ///   - knownProtocols: Optional set of recognised protocol JSON strings. When non-nil,
+    ///     ``AvroIPCRequest`` and ``AvroIPCResponse`` validate against this set and throw
+    ///     on unknown protocols. Useful for closed deployments.
+    public func makeIPCContext(
+        requestMeta:    [String: [UInt8]] = [:],
+        responseMeta:   [String: [UInt8]] = [:],
+        knownProtocols: Set<String>?      = nil
+    ) throws -> AvroIPCContext {
+        try guardRunning()
+        return try AvroIPCContext.standard(
+            avro:           Avro(),
+            requestMeta:    requestMeta,
+            responseMeta:   responseMeta,
+            knownProtocols: knownProtocols
+        )
+    }
+
+    // MARK: - Utilities
+
+    /// Returns the 16-byte MD5 hash of the given Avro protocol JSON string.
+    ///
+    /// Use this to produce the `clientHash` / `serverHash` values required by
+    /// ``AvroIPCClientConfig`` and ``AvroIPCServerConfig`` without depending on
+    /// an external MD5 library.
+    ///
+    ///     let hash = SwiftAvroRpc.md5Hash(of: myProtocolJSON)
+    public static func md5Hash(of protocolJSON: String) -> MD5Hash {
+        var hasher = Insecure.MD5()
+        hasher.update(data: Data(protocolJSON.utf8))
+        return Array(hasher.finalize())
+    }
+
+    // MARK: - IPC Server
+
+    /// Binds an Avro IPC server using the given configuration and returns
+    /// an ``AvroServerChannel`` representing the bound port.
+    ///
+    /// Each accepted TCP connection receives its own ``AvroIPCServer`` actor instance,
+    /// so handshake state and session cache are fully isolated per connection.
+    ///
+    /// - Parameter config: Server configuration including host, port, context, and handler.
+    /// - Returns: An ``AvroServerChannel`` that can be closed when the server should stop.
+    @discardableResult
+    public func makeServer(_ config: AvroIPCServerConfig) async throws -> AvroServerChannel {
+        try guardRunning()
+        let channel = try await AvroIPCServerBootstrap(
+            eventLoopGroup: eventLoopGroup,
+            context: config.context,
+            serverHash: config.serverHash,
+            serverProtocol: config.serverProtocol,
+            handler: config.handler
+        ).bind(using: config.transport)
+        return AvroServerChannel(channel: channel)
+    }
+
+    // MARK: - IPC Client
+
+    /// Creates and returns a connected ``AvroIPCClient`` using the given configuration.
+    ///
+    /// The client connects to the server immediately. The Avro IPC handshake is performed
+    /// transparently on the first `call` — no separate handshake step is required.
+    /// Session state is tracked in a per-client ``ClientSessionCache`` actor.
+    ///
+    /// - Parameter config: Client configuration including host, port, context, and protocol hashes.
+    /// - Returns: A connected ``AvroIPCClient`` ready to send RPC calls.
+    public func makeClient(_ config: AvroIPCClientConfig) async throws -> AvroIPCClient {
+        try guardRunning()
+        let client = try AvroIPCClient(
+            context: config.context,
+            clientHash: config.clientHash,
+            clientProtocol: config.clientProtocol,
+            serverHash: config.serverHash
+        )
+        try await client.connect(using: config.transport, eventLoopGroup: eventLoopGroup)
+        return client
+    }
+
+    // MARK: - HTTP IPC Server
+
+    /// Binds an Avro IPC server that accepts requests over HTTP (or HTTPS when `config.tls`
+    /// is set). All connections share a single ``AvroIPCServer`` actor so the handshake
+    /// session cache persists across requests without per-request re-negotiation.
+    ///
+    /// - Parameter config: HTTP server configuration including host, port, handler, and optional TLS.
+    /// - Returns: An ``AvroServerChannel`` that can be closed when the server should stop.
+    @discardableResult
+    public func makeHTTPServer(_ config: AvroIPCHTTPServerConfig) async throws -> AvroServerChannel {
+        try guardRunning()
+        let channel = try await AvroIPCHTTPServerBootstrap(
+            eventLoopGroup: eventLoopGroup,
+            context:        config.context,
+            serverHash:     config.serverHash,
+            serverProtocol: config.serverProtocol,
+            handler:        config.handler,
+            tlsContext:     config.tls?.sslContext
+        ).bind(host: config.host, port: config.port)
+        return AvroServerChannel(channel: channel)
+    }
+
+    // MARK: - HTTP IPC Client
+
+    /// Creates an Avro IPC client that sends each RPC call as an HTTP POST (or HTTPS when
+    /// `config.tls` is set). The handshake is performed transparently on the first call.
+    ///
+    /// Unlike the TCP client, the HTTP client opens a new connection per call, so no
+    /// explicit `disconnect()` is required.
+    ///
+    /// - Parameter config: HTTP client configuration including host, port, and optional TLS.
+    /// - Returns: A ready-to-use ``AvroIPCHTTPClient``.
+    public func makeHTTPClient(_ config: AvroIPCHTTPClientConfig) throws -> AvroIPCHTTPClient {
+        try guardRunning()
+        return try AvroIPCHTTPClient(
+            context:        config.context,
+            clientHash:     config.clientHash,
+            clientProtocol: config.clientProtocol,
+            serverHash:     config.serverHash,
+            host:           config.host,
+            port:           config.port,
+            path:           config.path,
+            eventLoopGroup: eventLoopGroup,
+            tlsContext:     config.tls?.sslContext
+        )
+    }
+
+    // MARK: - Lifecycle
+
+    /// Stops the managed NIO event loop group and releases all network resources.
+    ///
+    /// Call this once all clients have disconnected and all server channels have been closed.
+    /// After `stop()` returns, no further factory methods may be called on this instance.
+    /// Calling `stop()` more than once is safe — subsequent calls are no-ops.
+    public func stop() async throws {
+        guard case .running = state else { return }
+        state = .stopped
+        try await eventLoopGroup.shutdownGracefully()
+    }
+
+    // MARK: - Private helpers
+
+    private func guardRunning() throws {
+        guard case .running = state else {
+            throw AvroIPCError.connectionClosed
+        }
+    }
+}

--- a/Tests/SwiftAvroCoreTests/AvroIPCFramingTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroIPCFramingTest.swift
@@ -1,0 +1,78 @@
+//
+//  AvroIPCFramingTest.swift
+//  SwiftAvroCoreTests
+//
+
+import Testing
+import Foundation
+@testable import SwiftAvroCore
+
+@Suite("Avro IPC Framing")
+struct AvroIPCFramingTest {
+
+    // MARK: - framing
+
+    @Test func framingProducesLengthPrefixedChunks() {
+        let payload = Data(repeating: 0xAB, count: 10)
+        let framed = payload.framing(maxFrameLength: 4)
+
+        // Expected: [0,0,0,4] + 4 bytes + [0,0,0,4] + 4 bytes + [0,0,0,2] + 2 bytes + [0,0,0,0]
+        #expect(framed.count == 3 * 4 + 10 + 4)
+        // Terminator is the last 4 bytes
+        #expect(framed.suffix(4) == Data([0, 0, 0, 0]))
+    }
+
+    @Test func framingEmptyDataYieldsOnlyTerminator() {
+        let framed = Data().framing()
+        #expect(framed == Data([0, 0, 0, 0]))
+    }
+
+    @Test func framingZeroMaxFrameLengthYieldsOnlyTerminator() {
+        let framed = Data(repeating: 0xFF, count: 8).framing(maxFrameLength: 0)
+        #expect(framed == Data([0, 0, 0, 0]))
+    }
+
+    // MARK: - deFraming
+
+    @Test func deFramingRoundTrip() {
+        let original = Data([1, 2, 3, 4, 5, 6, 7, 8])
+        let frames = original.framing(maxFrameLength: 4).deFraming()
+        #expect(frames.count == 2)
+        #expect(frames[0] == Data([1, 2, 3, 4]))
+        #expect(frames[1] == Data([5, 6, 7, 8]))
+    }
+
+    @Test func deFramingEmptyInputYieldsNoFrames() {
+        #expect(Data().deFraming().isEmpty)
+    }
+
+    @Test func deFramingStopsAtZeroLengthTerminator() {
+        // Two frames followed by a terminator followed by extra bytes that must be ignored.
+        var raw = Data()
+        raw.append(contentsOf: [0, 0, 0, 2, 0xAA, 0xBB])  // frame 1
+        raw.append(contentsOf: [0, 0, 0, 0])               // terminator
+        raw.append(contentsOf: [0, 0, 0, 2, 0xCC, 0xDD])  // must not be read
+        let frames = raw.deFraming()
+        #expect(frames.count == 1)
+        #expect(frames[0] == Data([0xAA, 0xBB]))
+    }
+
+    @Test func deFramingTruncatedFrameIsIgnored() {
+        // Length prefix says 8 bytes but only 3 are present.
+        let raw = Data([0, 0, 0, 8, 0x01, 0x02, 0x03])
+        let frames = raw.deFraming()
+        #expect(frames.isEmpty)
+    }
+
+    // MARK: - deFramed
+
+    @Test func deFramedConcatenatesPayloads() {
+        let original = Data([1, 2, 3, 4, 5, 6, 7, 8])
+        let reassembled = original.framing(maxFrameLength: 4).deFramed()
+        #expect(reassembled == original)
+    }
+
+    @Test func deFramedEmptyInputIsEmpty() {
+        #expect(Data().deFramed() == Data())
+    }
+}

--- a/Tests/SwiftAvroRpcTests/AvroIPCHTTPTests.swift
+++ b/Tests/SwiftAvroRpcTests/AvroIPCHTTPTests.swift
@@ -1,0 +1,304 @@
+//
+//  AvroIPCHTTPTests.swift
+//  SwiftAvroRpcTests
+//
+//  Created by Yang Liu on 09/05/2026.
+//
+
+import Testing
+import Foundation
+@testable import SwiftAvroCore
+@testable import SwiftAvroRpc
+
+// MARK: - AvroIPCHTTPServerConfig tests
+
+@Suite("AvroIPCHTTPServerConfig")
+struct AvroIPCHTTPServerConfigTests {
+
+    @Test("Default host is 0.0.0.0 and path is /")
+    func defaultHostAndPath() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        let config  = AvroIPCHTTPServerConfig(
+            port:           9090,
+            context:        context,
+            serverHash:     testServerHash,
+            serverProtocol: helloProtocol,
+            handler:        EchoHandler()
+        )
+        #expect(config.host == "0.0.0.0")
+        #expect(config.path == "/")
+        #expect(config.tls  == nil)
+        try await rpc.stop()
+    }
+
+    @Test("All properties are stored correctly")
+    func propertiesStoredCorrectly() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        let config  = AvroIPCHTTPServerConfig(
+            host:           "127.0.0.1",
+            port:           8080,
+            path:           "/avro",
+            context:        context,
+            serverHash:     testServerHash,
+            serverProtocol: helloProtocol,
+            handler:        EchoHandler()
+        )
+        #expect(config.host           == "127.0.0.1")
+        #expect(config.port           == 8080)
+        #expect(config.path           == "/avro")
+        #expect(config.serverHash     == testServerHash)
+        #expect(config.serverProtocol == helloProtocol)
+        try await rpc.stop()
+    }
+}
+
+// MARK: - AvroIPCHTTPClientConfig tests
+
+@Suite("AvroIPCHTTPClientConfig")
+struct AvroIPCHTTPClientConfigTests {
+
+    @Test("Default path is /")
+    func defaultPath() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        let config  = AvroIPCHTTPClientConfig(
+            host:           "127.0.0.1",
+            port:           8080,
+            context:        context,
+            clientHash:     testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash:     testServerHash
+        )
+        #expect(config.path == "/")
+        #expect(config.tls  == nil)
+        try await rpc.stop()
+    }
+
+    @Test("All properties are stored correctly")
+    func propertiesStoredCorrectly() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        let config  = AvroIPCHTTPClientConfig(
+            host:           "127.0.0.1",
+            port:           8080,
+            path:           "/avro",
+            context:        context,
+            clientHash:     testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash:     testServerHash
+        )
+        #expect(config.host           == "127.0.0.1")
+        #expect(config.port           == 8080)
+        #expect(config.path           == "/avro")
+        #expect(config.clientHash     == testClientHash)
+        #expect(config.clientProtocol == helloProtocol)
+        #expect(config.serverHash     == testServerHash)
+        try await rpc.stop()
+    }
+}
+
+// MARK: - HTTP server lifecycle tests
+
+@Suite("HTTP server lifecycle")
+struct HTTPServerLifecycleTests {
+
+    @Test("makeHTTPServer binds and reports a local address")
+    func makeHTTPServerBinds() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeHTTPServer(AvroIPCHTTPServerConfig(
+            host:           "127.0.0.1",
+            port:           0,
+            context:        context,
+            serverHash:     testServerHash,
+            serverProtocol: helloProtocol,
+            handler:        EchoHandler()
+        ))
+        #expect(server.localAddress != nil)
+
+        try await server.close()
+        try await rpc.stop()
+    }
+
+    @Test("makeHTTPServer throws after stop()")
+    func makeHTTPServerThrowsAfterStop() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        try await rpc.stop()
+
+        await #expect(throws: (any Error).self) {
+            try await rpc.makeHTTPServer(AvroIPCHTTPServerConfig(
+                port:           0,
+                context:        context,
+                serverHash:     testServerHash,
+                serverProtocol: helloProtocol,
+                handler:        EchoHandler()
+            ))
+        }
+    }
+}
+
+// MARK: - HTTP end-to-end tests
+
+@Suite("HTTP IPC end-to-end")
+struct HTTPIPCEndToEndTests {
+
+    @Test("HTTP client and server complete handshake and call")
+    func handshakeAndCall() async throws {
+        let rpc     = SwiftAvroRpc(threads: 2)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeHTTPServer(AvroIPCHTTPServerConfig(
+            host:           "127.0.0.1",
+            port:           0,
+            context:        context,
+            serverHash:     testServerHash,
+            serverProtocol: helloProtocol,
+            handler:        GreetingHandler()
+        ))
+
+        let port   = extractPort(from: server.localAddress)
+        let client = try await rpc.makeHTTPClient(AvroIPCHTTPClientConfig(
+            host:           "127.0.0.1",
+            port:           port,
+            context:        context,
+            clientHash:     testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash:     testServerHash
+        ))
+
+        let response: Greeting = try await client.call(
+            messageName: "hello",
+            parameters:  [Greeting(message: "hi")],
+            as:          Greeting.self
+        )
+        #expect(response.message == "hello back")
+
+        try await server.close()
+        try await rpc.stop()
+    }
+
+    @Test("Multiple sequential HTTP calls succeed")
+    func multipleSequentialCalls() async throws {
+        let rpc     = SwiftAvroRpc(threads: 2)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeHTTPServer(AvroIPCHTTPServerConfig(
+            host:           "127.0.0.1",
+            port:           0,
+            context:        context,
+            serverHash:     testServerHash,
+            serverProtocol: helloProtocol,
+            handler:        GreetingHandler()
+        ))
+
+        let port   = extractPort(from: server.localAddress)
+        let client = try await rpc.makeHTTPClient(AvroIPCHTTPClientConfig(
+            host:           "127.0.0.1",
+            port:           port,
+            context:        context,
+            clientHash:     testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash:     testServerHash
+        ))
+
+        for i in 0..<5 {
+            let response: Greeting = try await client.call(
+                messageName: "hello",
+                parameters:  [Greeting(message: "call-\(i)")],
+                as:          Greeting.self
+            )
+            #expect(response.message == "hello back")
+        }
+
+        try await server.close()
+        try await rpc.stop()
+    }
+
+    @Test("Multiple HTTP clients share the server session cache")
+    func multipleClientsShareServerSessionCache() async throws {
+        let rpc     = SwiftAvroRpc(threads: 2)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeHTTPServer(AvroIPCHTTPServerConfig(
+            host:           "127.0.0.1",
+            port:           0,
+            context:        context,
+            serverHash:     testServerHash,
+            serverProtocol: helloProtocol,
+            handler:        GreetingHandler()
+        ))
+        let port = extractPort(from: server.localAddress)
+
+        // Three independent HTTP clients — each performs its own handshake.
+        // The shared AvroIPCServer actor accumulates the session cache across them.
+        let clients = try await withThrowingTaskGroup(of: AvroIPCHTTPClient.self) { group in
+            for _ in 0..<3 {
+                group.addTask {
+                    try await rpc.makeHTTPClient(AvroIPCHTTPClientConfig(
+                        host:           "127.0.0.1",
+                        port:           port,
+                        context:        context,
+                        clientHash:     testClientHash,
+                        clientProtocol: helloProtocol,
+                        serverHash:     testServerHash
+                    ))
+                }
+            }
+            var result: [AvroIPCHTTPClient] = []
+            for try await client in group { result.append(client) }
+            return result
+        }
+
+        for client in clients {
+            let response: Greeting = try await client.call(
+                messageName: "hello",
+                parameters:  [Greeting(message: "ping")],
+                as:          Greeting.self
+            )
+            #expect(response.message == "hello back")
+        }
+
+        try await server.close()
+        try await rpc.stop()
+    }
+
+    @Test("HTTP server handler error returns server-error to client")
+    func serverHandlerErrorReturnsError() async throws {
+        let rpc     = SwiftAvroRpc(threads: 2)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeHTTPServer(AvroIPCHTTPServerConfig(
+            host:           "127.0.0.1",
+            port:           0,
+            context:        context,
+            serverHash:     testServerHash,
+            serverProtocol: helloProtocol,
+            handler:        FailingHandler()
+        ))
+
+        let port   = extractPort(from: server.localAddress)
+        let client = try await rpc.makeHTTPClient(AvroIPCHTTPClientConfig(
+            host:           "127.0.0.1",
+            port:           port,
+            context:        context,
+            clientHash:     testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash:     testServerHash
+        ))
+
+        await #expect(throws: (any Error).self) {
+            try await client.call(
+                messageName: "hello",
+                parameters:  [Greeting(message: "will fail")],
+                as:          Greeting.self
+            )
+        }
+
+        try await server.close()
+        try await rpc.stop()
+    }
+}

--- a/Tests/SwiftAvroRpcTests/AvroIPCTests.swift
+++ b/Tests/SwiftAvroRpcTests/AvroIPCTests.swift
@@ -1,0 +1,527 @@
+//
+//  SwiftAvroRpcTests.swift
+//  SwiftAvroRpcTests
+//
+//  Created by Yang Liu on 06/04/2026.
+//
+
+import Testing
+import Foundation
+@testable import SwiftAvroCore
+@testable import SwiftAvroRpc
+
+// MARK: - V2 protocol (schema evolution tests only)
+
+/// V2 server protocol: Greeting gains `language` (default "en") for request evolution tests.
+private let helloProtocolV2 = """
+{
+  "namespace": "com.acme",
+  "protocol": "HelloWorld",
+  "types": [
+    {"name": "Greeting", "type": "record", "fields": [
+      {"name": "message",  "type": "string"},
+      {"name": "language", "type": "string", "default": "en"}
+    ]},
+    {"name": "Curse", "type": "error", "fields": [{"name": "message", "type": "string"}]}
+  ],
+  "messages": {
+    "hello": {
+      "request":  [{"name": "greeting", "type": "Greeting"}],
+      "response": "Greeting",
+      "errors":   ["Curse"]
+    }
+  }
+}
+"""
+
+private struct GreetingV2: Codable, Sendable, Equatable {
+    var message:  String
+    var language: String
+}
+
+// MARK: - SwiftAvroRpc lifecycle tests
+
+@Suite("SwiftAvroRpc lifecycle")
+struct SwiftAvroRpcLifecycleTests {
+
+    @Test("Init creates a running instance")
+    func initCreatesRunningInstance() async throws {
+        let rpc = SwiftAvroRpc(threads: 1)
+        _ = try await rpc.makeContainer(schema: """
+            {"type":"record","name":"X","fields":[{"name":"a","type":"int"}]}
+            """)
+        try await rpc.stop()
+    }
+
+    @Test("stop() is idempotent")
+    func stopIsIdempotent() async throws {
+        let rpc = SwiftAvroRpc(threads: 1)
+        try await rpc.stop()
+        try await rpc.stop()
+    }
+
+    @Test("Factory methods throw after stop()")
+    func factoryThrowsAfterStop() async throws {
+        let rpc = SwiftAvroRpc(threads: 1)
+        try await rpc.stop()
+        await #expect(throws: (any Error).self) {
+            try await rpc.makeContainer(schema: """
+                {"type":"record","name":"X","fields":[{"name":"a","type":"int"}]}
+                """)
+        }
+    }
+
+    @Test("makeIPCContext returns context with correct schema names")
+    func makeIPCContextSchemaNames() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        #expect(context.requestSchema.getName()  == "HandshakeRequest")
+        #expect(context.responseSchema.getName() == "HandshakeResponse")
+        #expect(context.metaSchema.getTypeName() == "map")
+        try await rpc.stop()
+    }
+}
+
+// MARK: - SwiftAvroRpc server tests
+
+@Suite("SwiftAvroRpc server")
+struct SwiftAvroRpcServerTests {
+
+    @Test("makeServer binds and reports a local address")
+    func makeServerBinds() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+
+        let config = AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: EchoHandler()
+        )
+
+        let server = try await rpc.makeServer(config)
+        #expect(server.localAddress != nil)
+
+        try await server.close()
+        try await rpc.stop()
+    }
+
+    @Test("makeServer throws after stop()")
+    func makeServerThrowsAfterStop() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        try await rpc.stop()
+
+        let config = AvroIPCServerConfig(
+            transport: TCPTransport(port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: EchoHandler()
+        )
+        await #expect(throws: (any Error).self) {
+            try await rpc.makeServer(config)
+        }
+    }
+
+    @Test("Two servers can bind on different ports simultaneously")
+    func twoServersOnDifferentPorts() async throws {
+        let rpc     = SwiftAvroRpc(threads: 2)
+        let context = try await rpc.makeIPCContext()
+
+        let s1 = try await rpc.makeServer(AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: EchoHandler()
+        ))
+        let s2 = try await rpc.makeServer(AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: EchoHandler()
+        ))
+
+        #expect(s1.localAddress != s2.localAddress)
+
+        try await s1.close()
+        try await s2.close()
+        try await rpc.stop()
+    }
+}
+
+// MARK: - SwiftAvroRpc client tests
+
+@Suite("SwiftAvroRpc client")
+struct SwiftAvroRpcClientTests {
+
+    @Test("makeClient connects successfully")
+    func makeClientConnects() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeServer(AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: EchoHandler()
+        ))
+
+        let port   = extractPort(from: server.localAddress)
+        let client = try await rpc.makeClient(AvroIPCClientConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: port),
+            context: context,
+            clientHash: testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash: testServerHash
+        ))
+
+        try await client.disconnect()
+        try await server.close()
+        try await rpc.stop()
+    }
+
+    @Test("makeClient throws after stop()")
+    func makeClientThrowsAfterStop() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        try await rpc.stop()
+
+        await #expect(throws: (any Error).self) {
+            try await rpc.makeClient(AvroIPCClientConfig(
+                transport: TCPTransport(host: "127.0.0.1", port: 9999),
+                context: context,
+                clientHash: testClientHash,
+                clientProtocol: helloProtocol,
+                serverHash: testServerHash
+            ))
+        }
+    }
+
+    @Test("disconnect is safe to call multiple times")
+    func disconnectIsIdempotent() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeServer(AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: EchoHandler()
+        ))
+
+        let port   = extractPort(from: server.localAddress)
+        let client = try await rpc.makeClient(AvroIPCClientConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: port),
+            context: context,
+            clientHash: testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash: testServerHash
+        ))
+
+        try await client.disconnect()
+        try await client.disconnect()
+
+        try await server.close()
+        try await rpc.stop()
+    }
+}
+
+// MARK: - SwiftAvroRpc end-to-end tests
+
+@Suite("SwiftAvroRpc end-to-end")
+struct SwiftAvroRpcEndToEndTests {
+
+    @Test("Client and server complete handshake")
+    func handshakeCompletes() async throws {
+        let rpc     = SwiftAvroRpc(threads: 2)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeServer(AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: GreetingHandler()
+        ))
+
+        let port   = extractPort(from: server.localAddress)
+        let client = try await rpc.makeClient(AvroIPCClientConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: port),
+            context: context,
+            clientHash: testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash: testServerHash
+        ))
+
+        let response: Greeting = try await client.call(
+            messageName: "hello",
+            parameters: [Greeting(message: "hi")],
+            as: Greeting.self
+        )
+        #expect(response.message == "hello back")
+
+        try await client.disconnect()
+        try await server.close()
+        try await rpc.stop()
+    }
+
+    @Test("Multiple sequential calls on the same connection succeed")
+    func multipleSequentialCalls() async throws {
+        let rpc     = SwiftAvroRpc(threads: 2)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeServer(AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: GreetingHandler()
+        ))
+
+        let port   = extractPort(from: server.localAddress)
+        let client = try await rpc.makeClient(AvroIPCClientConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: port),
+            context: context,
+            clientHash: testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash: testServerHash
+        ))
+
+        for i in 0..<5 {
+            let response: Greeting = try await client.call(
+                messageName: "hello",
+                parameters: [Greeting(message: "call-\(i)")],
+                as: Greeting.self
+            )
+            #expect(response.message == "hello back")
+        }
+
+        try await client.disconnect()
+        try await server.close()
+        try await rpc.stop()
+    }
+
+    @Test("Multiple clients connect to the same server")
+    func multipleClientsOneServer() async throws {
+        let rpc     = SwiftAvroRpc(threads: 2)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeServer(AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: GreetingHandler()
+        ))
+
+        let port = extractPort(from: server.localAddress)
+
+        let clients = try await withThrowingTaskGroup(of: AvroIPCClient.self) { group in
+            for _ in 0..<3 {
+                group.addTask {
+                    try await rpc.makeClient(AvroIPCClientConfig(
+                        transport: TCPTransport(host: "127.0.0.1", port: port),
+                        context: context,
+                        clientHash: testClientHash,
+                        clientProtocol: helloProtocol,
+                        serverHash: testServerHash
+                    ))
+                }
+            }
+            var result: [AvroIPCClient] = []
+            for try await client in group { result.append(client) }
+            return result
+        }
+
+        for client in clients {
+            let response: Greeting = try await client.call(
+                messageName: "hello",
+                parameters: [Greeting(message: "ping")],
+                as: Greeting.self
+            )
+            #expect(response.message == "hello back")
+            try await client.disconnect()
+        }
+
+        try await server.close()
+        try await rpc.stop()
+    }
+
+    @Test("Server handler error closes connection gracefully")
+    func serverHandlerErrorClosesConnection() async throws {
+        let rpc     = SwiftAvroRpc(threads: 2)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeServer(AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: FailingHandler()
+        ))
+
+        let port   = extractPort(from: server.localAddress)
+        let client = try await rpc.makeClient(AvroIPCClientConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: port),
+            context: context,
+            clientHash: testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash: testServerHash
+        ))
+
+        await #expect(throws: (any Error).self) {
+            try await client.call(
+                messageName: "hello",
+                parameters: [Greeting(message: "will fail")],
+                as: Greeting.self
+            )
+        }
+
+        try await server.close()
+        try await rpc.stop()
+    }
+}
+
+// MARK: - AvroIPCServerConfig tests
+
+@Suite("AvroIPCServerConfig")
+struct AvroIPCServerConfigTests {
+
+    @Test("Default host is 0.0.0.0")
+    func defaultHost() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        let config  = AvroIPCServerConfig(
+            transport: TCPTransport(port: 9090),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: EchoHandler()
+        )
+        let tcp = config.transport as? TCPTransport
+        #expect(tcp?.host == "0.0.0.0")
+        try await rpc.stop()
+    }
+
+    @Test("All properties are stored correctly")
+    func propertiesStoredCorrectly() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        let config  = AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 9090),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocol,
+            handler: EchoHandler()
+        )
+        let tcp = config.transport as? TCPTransport
+        #expect(tcp?.host           == "127.0.0.1")
+        #expect(tcp?.port           == 9090)
+        #expect(config.serverHash     == testServerHash)
+        #expect(config.serverProtocol == helloProtocol)
+        try await rpc.stop()
+    }
+}
+
+// MARK: - AvroIPCClientConfig tests
+
+@Suite("AvroIPCClientConfig")
+struct AvroIPCClientConfigTests {
+
+    @Test("All properties are stored correctly")
+    func propertiesStoredCorrectly() async throws {
+        let rpc     = SwiftAvroRpc(threads: 1)
+        let context = try await rpc.makeIPCContext()
+        let config  = AvroIPCClientConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 9090),
+            context: context,
+            clientHash: testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash: testServerHash
+        )
+        let tcp = config.transport as? TCPTransport
+        #expect(tcp?.host           == "127.0.0.1")
+        #expect(tcp?.port           == 9090)
+        #expect(config.clientHash     == testClientHash)
+        #expect(config.clientProtocol == helloProtocol)
+        #expect(config.serverHash     == testServerHash)
+        try await rpc.stop()
+    }
+}
+
+// MARK: - IPC request schema evolution tests
+
+/// Handler that requires schema evolution: decodes with writer+reader schemas and
+/// echoes the language field back in the response so the test can verify evolution.
+private struct EvolvingGreetingHandler: AvroIPCHandler {
+    func handle(messageName: String, requestData: Data) async throws -> Data {
+        throw AvroIPCError.noHandler("EvolvingGreetingHandler requires schema context")
+    }
+
+    func handle(
+        messageName:   String,
+        requestData:   Data,
+        writerSchemas: [AvroSchema],
+        readerSchemas: [AvroSchema]
+    ) async throws -> Data {
+        let avro   = Avro()
+        let reader = avro.makeDataReader(data: requestData)
+        let g: GreetingV2 = try reader.decode(
+            writerSchema: writerSchemas[0],
+            readerSchema: readerSchemas[0]
+        )
+        let v2ResponseSchema = avro.newSchema(schema: """
+            {"type":"record","name":"Greeting","namespace":"com.acme",
+             "fields":[{"name":"message","type":"string"},
+                       {"name":"language","type":"string","default":"en"}]}
+            """)!
+        return try avro.encodeFrom(
+            GreetingV2(message: "\(g.message):\(g.language)", language: g.language),
+            schema: v2ResponseSchema
+        )
+    }
+}
+
+@Suite("SwiftAvroRpc IPC request evolution")
+struct SwiftAvroRpcIPCRequestEvolutionTests {
+
+    @Test("Client V1 schema, server V2 schema — language default filled via evolution")
+    func requestEvolution() async throws {
+        let rpc     = SwiftAvroRpc(threads: 2)
+        let context = try await rpc.makeIPCContext()
+
+        let server = try await rpc.makeServer(AvroIPCServerConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: 0),
+            context: context,
+            serverHash: testServerHash,
+            serverProtocol: helloProtocolV2,
+            handler: EvolvingGreetingHandler()
+        ))
+
+        let port   = extractPort(from: server.localAddress)
+        let client = try await rpc.makeClient(AvroIPCClientConfig(
+            transport: TCPTransport(host: "127.0.0.1", port: port),
+            context: context,
+            clientHash: testClientHash,
+            clientProtocol: helloProtocol,
+            serverHash: testServerHash
+        ))
+
+        let response: Greeting = try await client.call(
+            messageName: "hello",
+            parameters:  [Greeting(message: "hi")],
+            as:          Greeting.self
+        )
+        #expect(response.message == "hi:en")
+
+        try await client.disconnect()
+        try await server.close()
+        try await rpc.stop()
+    }
+}

--- a/Tests/SwiftAvroRpcTests/AvroObjectContainerTests.swift
+++ b/Tests/SwiftAvroRpcTests/AvroObjectContainerTests.swift
@@ -1,0 +1,386 @@
+//
+//  AvroFileObjectContainerTests.swift
+//  SwiftAvroRpc
+//
+//  Created by Yang Liu on 05/04/2026.
+//
+
+import Testing
+import Foundation
+import SwiftAvroCore
+@testable import SwiftAvroRpc
+
+// MARK: - Helper
+
+func makeSyncMarker() -> [UInt8] {
+    (0..<16).map { _ in UInt8.random(in: 0...255) }
+}
+
+@Suite("AvroFileObjectContainer")
+struct AvroFileObjectContainerTests {
+
+    // MARK: Init
+
+    @Test("Init succeeds with null codec")
+    func initNullCodec() throws {
+        #expect(throws: Never.self) {
+            try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        }
+    }
+
+    @Test("Init succeeds with deflate codec")
+    func initDeflateCodec() throws {
+        #expect(throws: Never.self) {
+            try AvroFileObjectContainer(
+                schema: sensorSchema,
+                codec: try CodecFactory.make(named: AvroReservedConstants.deflateCodec),
+                syncMarker: makeSyncMarker()
+            )
+        }
+    }
+
+    // MARK: Write
+
+    @Test("Write single object produces non-empty data")
+    func writeSingleObject() async throws {
+        let container = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        let data = try await container.write(objects: [SimpleRecord(a: 42, b: "hello")])
+        #expect(!data.isEmpty)
+    }
+
+    @Test("Write produces Avro magic bytes")
+    func writeMagicBytes() async throws {
+        let container = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        let data = try await container.write(objects: [SimpleRecord(a: 1, b: "test")])
+        #expect(Array(data.prefix(4)) == [0x4F, 0x62, 0x6A, 0x01])
+    }
+
+    @Test("Write multiple objects produces non-empty data")
+    func writeMultipleObjects() async throws {
+        let container = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        let records = (0..<10).map { SimpleRecord(a: Int64($0), b: "record-\($0)") }
+        let data = try await container.write(objects: records)
+        #expect(!data.isEmpty)
+    }
+
+    @Test("Write with each codec produces non-empty data",
+          arguments: [AvroReservedConstants.nullCodec,
+                      AvroReservedConstants.deflateCodec,
+                      AvroReservedConstants.lz4Codec,
+                      AvroReservedConstants.xzCodec])
+    func writeWithCodec(codecName: String) async throws {
+        let original = SensorReading(id: 1, temperature: 22.5, location: "Auckland")
+        let codec = try CodecFactory.make(named: codecName)
+        let container = try AvroFileObjectContainer(schema: sensorSchema, codec: codec, syncMarker: makeSyncMarker())
+        let encoded = try await container.write(objects: [original])
+
+        #expect(!encoded.isEmpty)
+        #expect(Array(encoded.prefix(4)) == [0x4F, 0x62, 0x6A, 0x01])
+
+        let reader = try AvroFileObjectContainer(schema: sensorSchema, codec: codec, syncMarker: makeSyncMarker())
+        let decoded: [SensorReading] = try await reader.read(from: encoded, as: SensorReading.self)
+        #expect(decoded.count == 1)
+        #expect(decoded[0] == original)
+    }
+
+    // MARK: addObject + flush
+
+    @Test("addObject then flush produces non-empty data")
+    func addObjectThenFlush() async throws {
+        let container = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        try await container.addObject(SimpleRecord(a: 1, b: "one"))
+        try await container.addObject(SimpleRecord(a: 2, b: "two"))
+        let data = try await container.flush()
+        #expect(!data.isEmpty)
+    }
+
+    // MARK: Round-trips
+
+    @Test("Round-trip single record with null codec")
+    func roundTripSingleNull() async throws {
+        let original = [SimpleRecord(a: 99, b: "avro")]
+        let container = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        let encoded = try await container.write(objects: original)
+
+        let decoded: [SimpleRecord] = try await container.read(from: encoded, as: SimpleRecord.self)
+        #expect(decoded == original)
+    }
+
+    @Test("Round-trip multiple records with null codec")
+    func roundTripMultipleNull() async throws {
+        let original = (0..<20).map { SimpleRecord(a: Int64($0), b: "item-\($0)") }
+        let container = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        let encoded = try await container.write(objects: original)
+
+        let decoded: [SimpleRecord] = try await container.read(from: encoded, as: SimpleRecord.self)
+        #expect(decoded == original)
+    }
+
+    @Test("Round-trip sensor records with each codec",
+          arguments: [AvroReservedConstants.nullCodec,
+                      AvroReservedConstants.deflateCodec,
+                      AvroReservedConstants.lz4Codec,
+                      AvroReservedConstants.xzCodec])
+    func roundTripSensorRecords(codecName: String) async throws {
+        let original = [
+            SensorReading(id: 1, temperature: 22.5, location: "Auckland"),
+            SensorReading(id: 2, temperature: 18.3, location: "Wellington"),
+            SensorReading(id: 3, temperature: 14.1, location: "Christchurch"),
+        ]
+        let codec = try CodecFactory.make(named: codecName)
+        let container = try AvroFileObjectContainer(schema: sensorSchema, codec: codec, syncMarker: makeSyncMarker())
+        let encoded = try await container.write(objects: original)
+
+        let decoded: [SensorReading] = try await container.read(from: encoded, as: SensorReading.self)
+        #expect(decoded == original)
+    }
+
+    // MARK: Compression ratio
+
+    @Test("Deflate output is smaller than null for repetitive data")
+    func deflateOutputIsSmaller() async throws {
+        let records = (0..<200).map {
+            SensorReading(id: Int32($0), temperature: 20.0, location: "repeated-location")
+        }
+        let container = try AvroFileObjectContainer(schema: sensorSchema, syncMarker: makeSyncMarker())
+        let nullData = try await container.write(objects: records)
+
+        let deflateWriter = try AvroFileObjectContainer(
+            schema: sensorSchema,
+            codec: try CodecFactory.make(named: AvroReservedConstants.deflateCodec),
+            syncMarker: makeSyncMarker()
+        )
+        let deflateData = try await deflateWriter.write(objects: records)
+        #expect(deflateData.count < nullData.count)
+    }
+
+    // MARK: Streaming
+
+    @Test("Stream yields all objects in order")
+    func streamYieldsAllObjects() async throws {
+        let original = (0..<5).map { SimpleRecord(a: Int64($0), b: "stream-\($0)") }
+        let writer = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        let encoded = try await writer.write(objects: original)
+
+        let reader = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        var streamed: [SimpleRecord] = []
+        for try await record in await reader.stream(from: encoded, as: SimpleRecord.self) {
+            streamed.append(record)
+        }
+        #expect(streamed == original)
+    }
+
+    // MARK: Error cases
+
+    @Test("Read from corrupt data throws")
+    func readCorruptDataThrows() async throws {
+        let reader = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        await #expect(throws: (any Error).self) {
+            try await reader.read(from: Data("this is not avro".utf8), as: SimpleRecord.self)
+        }
+    }
+
+    @Test("Read from empty data throws")
+    func readEmptyDataThrows() async throws {
+        let reader = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        await #expect(throws: (any Error).self) {
+            try await reader.read(from: Data(), as: SimpleRecord.self)
+        }
+    }
+
+    @Test("read throws for corrupt data")
+    func readCorruptTyped() async throws {
+        let reader = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        await #expect(throws: (any Error).self) {
+            _ = try await reader.read(from: Data("corrupt".utf8), as: SimpleRecord.self)
+        }
+    }
+
+    @Test("addObject then read round-trips with typed throws")
+    func addObjectRoundTrip() async throws {
+        let container = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        try await container.addObject(SimpleRecord(a: 10, b: "typed"))
+        try await container.addObject(SimpleRecord(a: 20, b: "throws"))
+        let data = try await container.flush()
+
+        let reader = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        let results: [SimpleRecord] = try await reader.read(from: data, as: SimpleRecord.self)
+        #expect(results == [SimpleRecord(a: 10, b: "typed"), SimpleRecord(a: 20, b: "throws")])
+    }
+}
+
+// MARK: - Custom codec
+
+/// A trivial codec whose compress and decompress are their own inverse —
+/// used to verify the custom codec interface without any real compression library.
+private struct ReverseCodec: CodecProtocol {
+    let name = "reverse"
+    func compress(data: Data) throws -> Data   { Data(data.reversed()) }
+    func decompress(data: Data) throws -> Data { Data(data.reversed()) }
+}
+
+@Suite("Custom codec")
+struct CustomCodecTests {
+
+    @Test("Direct injection round-trips with custom codec")
+    func directInjectionRoundTrip() async throws {
+        let original = [SimpleRecord(a: 7, b: "custom")]
+        let writer = try AvroFileObjectContainer(
+            schema: simpleSchema, codec: ReverseCodec(), syncMarker: makeSyncMarker()
+        )
+        let encoded = try await writer.write(objects: original)
+        #expect(!encoded.isEmpty)
+
+        let reader = try AvroFileObjectContainer(
+            schema: simpleSchema, codec: ReverseCodec(), syncMarker: makeSyncMarker()
+        )
+        let decoded: [SimpleRecord] = try await reader.read(from: encoded, as: SimpleRecord.self)
+        #expect(decoded == original)
+    }
+
+    @Test("Name-based lookup via AvroCodecRegistry round-trips")
+    func registryRoundTrip() async throws {
+        AvroCodecRegistry.register(ReverseCodec())
+
+        let original = [SimpleRecord(a: 99, b: "registry")]
+        let codec = try CodecFactory.make(named: "reverse")
+        let writer = try AvroFileObjectContainer(
+            schema: simpleSchema, codec: codec, syncMarker: makeSyncMarker()
+        )
+        let encoded = try await writer.write(objects: original)
+
+        let reader = try AvroFileObjectContainer(
+            schema: simpleSchema, codec: codec, syncMarker: makeSyncMarker()
+        )
+        let decoded: [SimpleRecord] = try await reader.read(from: encoded, as: SimpleRecord.self)
+        #expect(decoded == original)
+    }
+
+    @Test("Unknown codec name throws unsupportedCodec")
+    func unknownCodecThrows() {
+        #expect(throws: AvroCodecError.unsupportedCodec("nonexistent")) {
+            try CodecFactory.make(named: "nonexistent")
+        }
+    }
+
+    @Test("AvroCodecRegistry.codec(named:) returns nil for unregistered names")
+    func registryReturnsNilForUnknown() {
+        #expect(AvroCodecRegistry.codec(named: "no-such-codec") == nil)
+    }
+
+    @Test("AvroCodecRegistry.codec(named:) returns the registered codec")
+    func registryReturnsRegisteredCodec() {
+        AvroCodecRegistry.register(ReverseCodec())
+        let codec = AvroCodecRegistry.codec(named: "reverse")
+        #expect(codec != nil)
+        #expect(codec?.name == "reverse")
+    }
+}
+
+// MARK: - Schema evolution
+
+/// Reader schema: SimpleRecord with an extra optional field `c` that has a default.
+private let simpleSchemaV2 = """
+{
+    "type": "record",
+    "name": "SimpleRecord",
+    "fields": [
+        { "name": "a", "type": "long"   },
+        { "name": "b", "type": "string" },
+        { "name": "c", "type": "string", "default": "default-value" }
+    ]
+}
+"""
+
+/// Reader struct corresponding to `simpleSchemaV2`.
+private struct SimpleRecordV2: Codable, Sendable, Equatable {
+    var a: Int64
+    var b: String
+    var c: String
+}
+
+/// Writer schema: SensorReading without the `location` field.
+private let sensorSchemaV1 = """
+{
+    "type": "record",
+    "name": "SensorReading",
+    "fields": [
+        { "name": "id",          "type": "int"    },
+        { "name": "temperature", "type": "double" }
+    ]
+}
+"""
+
+/// Reader struct for the v1 sensor schema (no location field).
+private struct SensorReadingV1: Codable, Sendable, Equatable {
+    var id: Int32
+    var temperature: Double
+}
+
+@Suite("Schema evolution")
+struct SchemaEvolutionTests {
+
+    @Test("Reader adds a field with default when writer schema lacks it")
+    func readerAddsFieldWithDefault() async throws {
+        let writer = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        let encoded = try await writer.write(objects: [
+            SimpleRecord(a: 1, b: "hello"),
+            SimpleRecord(a: 2, b: "world"),
+        ])
+
+        let reader = try AvroFileObjectContainer(schema: simpleSchemaV2, syncMarker: makeSyncMarker())
+        let results: [SimpleRecordV2] = try await reader.read(
+            from: encoded, as: SimpleRecordV2.self, readerSchema: simpleSchemaV2
+        )
+        #expect(results == [
+            SimpleRecordV2(a: 1, b: "hello", c: "default-value"),
+            SimpleRecordV2(a: 2, b: "world", c: "default-value"),
+        ])
+    }
+
+    @Test("Reader drops a field absent from the reader schema")
+    func readerDropsExtraWriterField() async throws {
+        let writer = try AvroFileObjectContainer(schema: sensorSchema, syncMarker: makeSyncMarker())
+        let encoded = try await writer.write(objects: [
+            SensorReading(id: 10, temperature: 21.0, location: "Auckland"),
+            SensorReading(id: 11, temperature: 19.5, location: "Wellington"),
+        ])
+
+        let reader = try AvroFileObjectContainer(schema: sensorSchemaV1, syncMarker: makeSyncMarker())
+        let results: [SensorReadingV1] = try await reader.read(
+            from: encoded, as: SensorReadingV1.self, readerSchema: sensorSchemaV1
+        )
+        #expect(results == [
+            SensorReadingV1(id: 10, temperature: 21.0),
+            SensorReadingV1(id: 11, temperature: 19.5),
+        ])
+    }
+
+    @Test("Evolved stream yields schema-resolved objects in order")
+    func evolvedStreamYieldsObjects() async throws {
+        let writer = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        let original = (0..<4).map { SimpleRecord(a: Int64($0), b: "item-\($0)") }
+        let encoded = try await writer.write(objects: original)
+
+        let reader = try AvroFileObjectContainer(schema: simpleSchemaV2, syncMarker: makeSyncMarker())
+        var streamed: [SimpleRecordV2] = []
+        for try await record in await reader.stream(
+            from: encoded, as: SimpleRecordV2.self, readerSchema: simpleSchemaV2
+        ) {
+            streamed.append(record)
+        }
+        let expected = original.map { SimpleRecordV2(a: $0.a, b: $0.b, c: "default-value") }
+        #expect(streamed == expected)
+    }
+
+    @Test("Invalid reader schema JSON throws decodingFailed")
+    func invalidReaderSchemaThrows() async throws {
+        let writer = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        let encoded = try await writer.write(objects: [SimpleRecord(a: 1, b: "x")])
+
+        let reader = try AvroFileObjectContainer(schema: simpleSchema, syncMarker: makeSyncMarker())
+        await #expect(throws: AvroContainerError.decodingFailed("Invalid reader schema")) {
+            _ = try await reader.read(from: encoded, as: SimpleRecord.self, readerSchema: "not-valid-json{")
+        }
+    }
+}

--- a/Tests/SwiftAvroRpcTests/AvroObjectContainerTests.swift
+++ b/Tests/SwiftAvroRpcTests/AvroObjectContainerTests.swift
@@ -28,6 +28,7 @@ struct AvroFileObjectContainerTests {
         }
     }
 
+    #if canImport(Compression)
     @Test("Init succeeds with deflate codec")
     func initDeflateCodec() throws {
         #expect(throws: Never.self) {
@@ -38,6 +39,7 @@ struct AvroFileObjectContainerTests {
             )
         }
     }
+    #endif
 
     // MARK: Write
 
@@ -63,6 +65,7 @@ struct AvroFileObjectContainerTests {
         #expect(!data.isEmpty)
     }
 
+    #if canImport(Compression)
     @Test("Write with each codec produces non-empty data",
           arguments: [AvroReservedConstants.nullCodec,
                       AvroReservedConstants.deflateCodec,
@@ -82,6 +85,7 @@ struct AvroFileObjectContainerTests {
         #expect(decoded.count == 1)
         #expect(decoded[0] == original)
     }
+    #endif
 
     // MARK: addObject + flush
 
@@ -116,6 +120,7 @@ struct AvroFileObjectContainerTests {
         #expect(decoded == original)
     }
 
+    #if canImport(Compression)
     @Test("Round-trip sensor records with each codec",
           arguments: [AvroReservedConstants.nullCodec,
                       AvroReservedConstants.deflateCodec,
@@ -153,6 +158,7 @@ struct AvroFileObjectContainerTests {
         let deflateData = try await deflateWriter.write(objects: records)
         #expect(deflateData.count < nullData.count)
     }
+    #endif
 
     // MARK: Streaming
 

--- a/Tests/SwiftAvroRpcTests/SwiftAvroCodecTests.swift
+++ b/Tests/SwiftAvroRpcTests/SwiftAvroCodecTests.swift
@@ -1,0 +1,259 @@
+import Testing
+import Foundation
+import SwiftAvroCore
+@testable import SwiftAvroRpc
+
+// MARK: - Test Models
+
+struct SensorReading: Codable, Sendable, Equatable {
+    var id: Int32
+    var temperature: Double
+    var location: String
+}
+
+struct SimpleRecord: Codable, Sendable, Equatable {
+    var a: Int64
+    var b: String
+}
+
+// MARK: - Schemas
+
+let sensorSchema = """
+{
+    "type": "record",
+    "name": "SensorReading",
+    "fields": [
+        { "name": "id",          "type": "int"    },
+        { "name": "temperature", "type": "double" },
+        { "name": "location",    "type": "string" }
+    ]
+}
+"""
+
+let simpleSchema = """
+{
+    "type": "record",
+    "name": "SimpleRecord",
+    "fields": [
+        { "name": "a", "type": "long"   },
+        { "name": "b", "type": "string" }
+    ]
+}
+"""
+
+// MARK: - NullCodec
+
+@Suite("NullCodec")
+struct NullCodecTests {
+
+    let codec = NullCodec()
+
+    @Test("Name matches Avro constant")
+    func name() {
+        #expect(codec.name == AvroReservedConstants.nullCodec)
+    }
+}
+
+// MARK: - BuiltinCodec
+
+@Suite("BuiltinCodec")
+struct BuiltinCodecTests {
+
+    // MARK: Names
+
+    @Test("Deflate name matches constant")
+    func deflateName() {
+        #expect(BuiltinCodec(codecName: AvroReservedConstants.deflateCodec).name
+                == AvroReservedConstants.deflateCodec)
+    }
+
+    @Test("LZ4 name matches constant")
+    func lz4Name() {
+        #expect(BuiltinCodec(codecName: AvroReservedConstants.lz4Codec).name
+                == AvroReservedConstants.lz4Codec)
+    }
+
+    @Test("LZMA name matches constant")
+    func lzmaName() {
+        #expect(BuiltinCodec(codecName: AvroReservedConstants.xzCodec).name
+                == AvroReservedConstants.xzCodec)
+    }
+
+    // MARK: Round-trips
+
+    @Test("Deflate round-trip on repetitive data",
+          arguments: [AvroReservedConstants.deflateCodec,
+                      AvroReservedConstants.lz4Codec,
+                      AvroReservedConstants.xzCodec])
+    func roundTrip(codecName: String) throws {
+        let codec = BuiltinCodec(codecName: codecName)
+        let input = Data(repeating: 0x42, count: 4096)
+        let decompressed = try codec.decompress(data: try codec.compress(data: input))
+        #expect(decompressed == input)
+    }
+
+    @Test("Deflate round-trip on string data")
+    func deflateRoundTripString() throws {
+        let codec = BuiltinCodec(codecName: AvroReservedConstants.deflateCodec)
+        let input = Data(String(repeating: "SwiftAvroRpc ", count: 200).utf8)
+        let decompressed = try codec.decompress(data: try codec.compress(data: input))
+        #expect(decompressed == input)
+    }
+
+    @Test("Deflate compresses repetitive data to smaller size")
+    func deflateReducesSize() throws {
+        let codec = BuiltinCodec(codecName: AvroReservedConstants.deflateCodec)
+        let input = Data(repeating: 0x42, count: 4096)
+        let compressed = try codec.compress(data: input)
+        #expect(compressed.count < input.count)
+    }
+
+    // MARK: Empty data
+
+    @Test("Compress empty data throws emptySourceData")
+    func compressEmptyThrows() {
+        let codec = BuiltinCodec(codecName: AvroReservedConstants.deflateCodec)
+        #expect(throws: AvroCodecError.emptySourceData) {
+            try codec.compress(data: Data())
+        }
+    }
+
+    @Test("Decompress empty data throws emptySourceData")
+    func decompressEmptyThrows() {
+        let codec = BuiltinCodec(codecName: AvroReservedConstants.deflateCodec)
+        #expect(throws: AvroCodecError.emptySourceData) {
+            try codec.decompress(data: Data())
+        }
+    }
+
+    // MARK: Custom buffer size
+
+    @Test("Custom decompress buffer size still round-trips correctly")
+    func customBufferSize() throws {
+        let codec = BuiltinCodec(
+            codecName: AvroReservedConstants.deflateCodec,
+            decompressBufferSize: 1024 * 128
+        )
+        let input = Data(repeating: 0xCD, count: 4096)
+        let decompressed = try codec.decompress(data: try codec.compress(data: input))
+        #expect(decompressed == input)
+    }
+
+    // MARK: BuiltinCodec typed throws
+
+    @Test("compress throws AvroCodecError.emptySourceData for empty input")
+    func compressEmptyTyped() {
+        let codec = BuiltinCodec(codecName: AvroReservedConstants.deflateCodec)
+        #expect(throws: AvroCodecError.emptySourceData) {
+            try codec.compress(data: Data())
+        }
+    }
+
+    @Test("decompress throws AvroCodecError.emptySourceData for empty input")
+    func decompressEmptyTyped() {
+        let codec = BuiltinCodec(codecName: AvroReservedConstants.deflateCodec)
+        #expect(throws: AvroCodecError.emptySourceData) {
+            try codec.decompress(data: Data())
+        }
+    }
+
+    @Test("decompress throws AvroCodecError.decompressionFailed for garbage input")
+    func decompressGarbageTyped() {
+        let codec = BuiltinCodec(codecName: AvroReservedConstants.deflateCodec)
+        #expect(throws: AvroCodecError.decompressionFailed) {
+            try codec.decompress(data: Data([0xFF, 0xFE, 0xFD, 0xFC]))
+        }
+    }
+
+    @Test("typed error is exhaustively switchable without default",
+          arguments: [AvroReservedConstants.deflateCodec,
+                      AvroReservedConstants.lz4Codec,
+                      AvroReservedConstants.xzCodec])
+    func exhaustiveSwitch(codecName: String) {
+        let codec = BuiltinCodec(codecName: codecName)
+        do {
+            _ = try codec.compress(data: Data())
+        } catch {
+            switch error {
+            case .emptySourceData:
+                break // expected
+            case .compressionFailed, .decompressionFailed, .unsupportedCodec:
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+}
+
+// MARK: - CodecFactory
+
+@Suite("CodecFactory")
+struct CodecFactoryTests {
+
+    @Test("Makes NullCodec for null constant")
+    func makesNull() throws {
+        let codec = try CodecFactory.make(named: AvroReservedConstants.nullCodec)
+        #expect(codec.name == AvroReservedConstants.nullCodec)
+        #expect(codec is NullCodec)
+    }
+
+    @Test("Makes BuiltinCodec for known codec names",
+          arguments: [AvroReservedConstants.deflateCodec,
+                      AvroReservedConstants.lz4Codec,
+                      AvroReservedConstants.xzCodec])
+    func makesBuiltin(codecName: String) throws {
+        let codec = try CodecFactory.make(named: codecName)
+        #expect(codec.name == codecName)
+        #expect(codec is BuiltinCodec)
+    }
+
+    @Test("Unknown codec name throws unsupportedCodec")
+    func unknownCodecThrows() {
+        #expect(throws: AvroCodecError.unsupportedCodec("snappy")) {
+            try CodecFactory.make(named: "snappy")
+        }
+    }
+
+    // MARK: - CodecFactory typed throws
+
+    @Test("make throws AvroCodecError.unsupportedCodec for unknown codec")
+    func unsupportedCodecTyped() {
+        #expect(throws: AvroCodecError.unsupportedCodec("brotli")) {
+            try CodecFactory.make(named: "brotli")
+        }
+    }
+
+    @Test("make does not throw for known codecs",
+          arguments: [AvroReservedConstants.nullCodec,
+                      AvroReservedConstants.deflateCodec,
+                      AvroReservedConstants.lz4Codec,
+                      AvroReservedConstants.xzCodec])
+    func knownCodecSucceeds(codecName: String) throws {
+        let codec = try CodecFactory.make(named: codecName)
+        #expect(codec.name == codecName)
+    }
+}
+
+// MARK: - AvroIPCError
+
+@Suite("AvroIPCError")
+struct AvroIPCErrorTests {
+
+    @Test("error cases are Sendable")
+    func sendable() {
+        let errors: [any Error & Sendable] = [
+            AvroIPCError.handshakeFailed("test"),
+            AvroIPCError.encodingFailed("test"),
+            AvroIPCError.decodingFailed("test"),
+            AvroIPCError.connectionClosed,
+            AvroIPCError.timeout,
+            AvroIPCError.noHandler("test"),
+        ]
+        #expect(errors.count == 6)
+    }
+
+    @Test("error descriptions contain associated values")
+    func descriptions() {
+        let error = AvroIPCError.handshakeFailed("bad hash")
+        #expect("\(error)".contains("bad hash"))
+    }
+}

--- a/Tests/SwiftAvroRpcTests/SwiftAvroCodecTests.swift
+++ b/Tests/SwiftAvroRpcTests/SwiftAvroCodecTests.swift
@@ -54,8 +54,9 @@ struct NullCodecTests {
     }
 }
 
-// MARK: - BuiltinCodec
+// MARK: - BuiltinCodec (Apple platforms only)
 
+#if canImport(Compression)
 @Suite("BuiltinCodec")
 struct BuiltinCodecTests {
 
@@ -183,6 +184,7 @@ struct BuiltinCodecTests {
         }
     }
 }
+#endif
 
 // MARK: - CodecFactory
 
@@ -196,6 +198,27 @@ struct CodecFactoryTests {
         #expect(codec is NullCodec)
     }
 
+    @Test("Unknown codec name throws unsupportedCodec")
+    func unknownCodecThrows() {
+        #expect(throws: AvroCodecError.unsupportedCodec("snappy")) {
+            try CodecFactory.make(named: "snappy")
+        }
+    }
+
+    @Test("make throws AvroCodecError.unsupportedCodec for unknown codec")
+    func unsupportedCodecTyped() {
+        #expect(throws: AvroCodecError.unsupportedCodec("brotli")) {
+            try CodecFactory.make(named: "brotli")
+        }
+    }
+
+    @Test("make does not throw for null codec")
+    func nullCodecSucceeds() throws {
+        let codec = try CodecFactory.make(named: AvroReservedConstants.nullCodec)
+        #expect(codec.name == AvroReservedConstants.nullCodec)
+    }
+
+#if canImport(Compression)
     @Test("Makes BuiltinCodec for known codec names",
           arguments: [AvroReservedConstants.deflateCodec,
                       AvroReservedConstants.lz4Codec,
@@ -206,31 +229,15 @@ struct CodecFactoryTests {
         #expect(codec is BuiltinCodec)
     }
 
-    @Test("Unknown codec name throws unsupportedCodec")
-    func unknownCodecThrows() {
-        #expect(throws: AvroCodecError.unsupportedCodec("snappy")) {
-            try CodecFactory.make(named: "snappy")
-        }
-    }
-
-    // MARK: - CodecFactory typed throws
-
-    @Test("make throws AvroCodecError.unsupportedCodec for unknown codec")
-    func unsupportedCodecTyped() {
-        #expect(throws: AvroCodecError.unsupportedCodec("brotli")) {
-            try CodecFactory.make(named: "brotli")
-        }
-    }
-
-    @Test("make does not throw for known codecs",
-          arguments: [AvroReservedConstants.nullCodec,
-                      AvroReservedConstants.deflateCodec,
+    @Test("make does not throw for compression codecs",
+          arguments: [AvroReservedConstants.deflateCodec,
                       AvroReservedConstants.lz4Codec,
                       AvroReservedConstants.xzCodec])
-    func knownCodecSucceeds(codecName: String) throws {
+    func compressionCodecSucceeds(codecName: String) throws {
         let codec = try CodecFactory.make(named: codecName)
         #expect(codec.name == codecName)
     }
+#endif
 }
 
 // MARK: - AvroIPCError

--- a/Tests/SwiftAvroRpcTests/TestHelpers.swift
+++ b/Tests/SwiftAvroRpcTests/TestHelpers.swift
@@ -1,0 +1,77 @@
+//
+//  TestHelpers.swift
+//  SwiftAvroRpcTests
+//
+//  Shared fixtures used across AvroIPCTests and AvroIPCHTTPTests.
+//
+
+import Foundation
+import SwiftAvroCore
+@testable import SwiftAvroRpc
+
+// MARK: - Protocol
+
+let helloProtocol = """
+{
+  "namespace": "com.acme",
+  "protocol": "HelloWorld",
+  "types": [
+    {"name": "Greeting", "type": "record", "fields": [{"name": "message", "type": "string"}]},
+    {"name": "Curse",    "type": "error",  "fields": [{"name": "message", "type": "string"}]}
+  ],
+  "messages": {
+    "hello": {
+      "request":  [{"name": "greeting", "type": "Greeting"}],
+      "response": "Greeting",
+      "errors":   ["Curse"]
+    }
+  }
+}
+"""
+
+// MARK: - Hashes
+
+let testClientHash: MD5Hash = Array(repeating: 0x01, count: 16)
+let testServerHash: MD5Hash = Array(repeating: 0x02, count: 16)
+
+// MARK: - Types
+
+struct Greeting: Codable, Sendable, Equatable {
+    var message: String
+}
+
+// MARK: - Handlers
+
+struct EchoHandler: AvroIPCHandler {
+    func handle(messageName: String, requestData: Data) async throws -> Data {
+        requestData
+    }
+}
+
+struct GreetingHandler: AvroIPCHandler {
+    func handle(messageName: String, requestData: Data) async throws -> Data {
+        let avro   = Avro()
+        let schema = avro.newSchema(schema: """
+            {"type":"record","name":"Greeting","namespace":"com.acme",
+             "fields":[{"name":"message","type":"string"}]}
+            """)!
+        return try avro.encodeFrom(Greeting(message: "hello back"), schema: schema)
+    }
+}
+
+struct FailingHandler: AvroIPCHandler {
+    func handle(messageName: String, requestData: Data) async throws -> Data {
+        throw AvroIPCError.noHandler(messageName)
+    }
+}
+
+// MARK: - Utilities
+
+func extractPort(from address: String?) -> Int {
+    guard let address,
+          let colonIndex = address.lastIndex(of: ":"),
+          let port = Int(address[address.index(after: colonIndex)...]) else {
+        return 0
+    }
+    return port
+}


### PR DESCRIPTION
Add SwiftAvroRPC as a new SPM product
Copy SwiftAvroRpc NIO transport sources into Sources/SwiftAvroRpc/ and
  mirror its test suite into Tests/SwiftAvroRpcTests/. Update Package.swift
  to declare the new product and target with swift-nio, swift-nio-ssl, and
  swift-crypto dependencies.
SwiftAvroCore consumers who do not import SwiftAvroRpc pull in zero NIO
  or crypto dependencies — the dependency is additive only.