### PR TITLE
Fix Swift Int/long schema mismatch and schema ref resolution in Avro …

### DIFF
--- a/Sources/SwiftAvroCore/Codable/AvroEncodable.swift
+++ b/Sources/SwiftAvroCore/Codable/AvroEncodable.swift
@@ -295,7 +295,10 @@ private struct AvroKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerP
 
     mutating func encode(_ value: Int,    forKey key: K) throws {
         encodeNilIndicesBefore(forKey: key)
-        guard schema(for: key).isInt() || encodeUnionIndex(for: key, typeName: .int) else {
+        let s = schema(for: key)
+        guard s.isInt() || s.isLong()
+            || encodeUnionIndex(for: key, typeName: .long)
+            || encodeUnionIndex(for: key, typeName: .int) else {
             throw BinaryEncodingError.typeMismatchWithSchemaInt
         }
         encoder.primitive.encode(value)

--- a/Sources/SwiftAvroCore/IPC/AvroProtocol.swift
+++ b/Sources/SwiftAvroCore/IPC/AvroProtocol.swift
@@ -100,12 +100,12 @@ public struct AvroProtocol: Equatable, Codable, Sendable {
     public func getRequest(messageName: String) -> [AvroSchema]? {
         guard let message = messages?[messageName],
               let requestFields = message.request else { return nil }
-        return requestFields.compactMap { typeMap[$0.type] }
+        return requestFields.compactMap { typeMap[$0.type].map { resolveRefs($0) } }
     }
 
     public func getResponse(messageName: String) -> AvroSchema? {
         guard let response = messages?[messageName]?.response else { return nil }
-        return typeMap[response]
+        return typeMap[response].map { resolveRefs($0) }
     }
 
     public func getErrors(messageName: String) -> [String: AvroSchema]? {
@@ -118,6 +118,41 @@ public struct AvroProtocol: Equatable, Codable, Sendable {
     }
 
     // MARK: Private helpers
+
+    /// Recursively substitutes named-type references with their full definitions from `typeMap`.
+    ///
+    /// `encodeCall` receives schemas directly from this protocol's `typeMap`. Schemas in the
+    /// map may contain reference-only sub-schemas (e.g. `{"type": "array", "items": "Foo"}`)
+    /// rather than the full inline definition of `Foo`. The Avro binary encoder cannot drive
+    /// field-level encoding from a reference schema alone, so we substitute references here.
+    private func resolveRefs(_ schema: AvroSchema) -> AvroSchema {
+        switch schema {
+        case .recordSchema(var r):
+            for i in r.fields.indices {
+                r.fields[i].type = resolveRefs(r.fields[i].type)
+            }
+            return .recordSchema(r)
+        case .arraySchema(var a):
+            a.items = resolveRefs(a.items)
+            return .arraySchema(a)
+        case .mapSchema(var m):
+            m.values = resolveRefs(m.values)
+            return .mapSchema(m)
+        case .unionSchema(var u):
+            u.branches = u.branches.map { resolveRefs($0) }
+            return .unionSchema(u)
+        case .unknownSchema(let u):
+            // A bare string in the JSON like `"items": "DigestEntry"` is parsed as
+            // unknownSchema with name = "DigestEntry". getName() returns nil for this
+            // case, so we must extract the name here.
+            if let name = u.name, let resolved = typeMap[name] {
+                return resolveRefs(resolved)
+            }
+            return schema
+        default:
+            return schema
+        }
+    }
 
     struct StringCodingKey: CodingKey {
         let stringValue: String

--- a/Tests/SwiftAvroRpcTests/ServiceLayerTests.swift
+++ b/Tests/SwiftAvroRpcTests/ServiceLayerTests.swift
@@ -102,30 +102,30 @@ struct LoadBalancerTests {
 struct InMemoryCatalogTests {
 
     @Test("Register and discover a service")
-    func registerAndDiscover() async throws {
+    func registerAndDiscover() async {
         let catalog = InMemoryCatalog()
         let info = ServiceInfo(name: "greeter", version: "1.0", endpoint: .tcp(host: "h", port: 1), nodeID: "n1")
-        try await catalog.register(info)
-        let found = try await catalog.discover(serviceName: "greeter")
+        await catalog.register(info)
+        let found = await catalog.discover(serviceName: "greeter")
         #expect(found == [info])
     }
 
     @Test("Discover returns empty for unknown service")
-    func discoverUnknown() async throws {
+    func discoverUnknown() async {
         let catalog = InMemoryCatalog()
-        let found = try await catalog.discover(serviceName: "unknown")
+        let found = await catalog.discover(serviceName: "unknown")
         #expect(found.isEmpty)
     }
 
     @Test("Deregister removes all endpoints for a node")
-    func deregister() async throws {
+    func deregister() async {
         let catalog = InMemoryCatalog()
         let i1 = ServiceInfo(name: "svc", version: "1.0", endpoint: .tcp(host: "h", port: 1), nodeID: "n1")
         let i2 = ServiceInfo(name: "svc", version: "1.0", endpoint: .tcp(host: "h", port: 2), nodeID: "n2")
-        try await catalog.register(i1)
-        try await catalog.register(i2)
-        try await catalog.deregister(nodeID: "n1")
-        let found = try await catalog.discover(serviceName: "svc")
+        await catalog.register(i1)
+        await catalog.register(i2)
+        await catalog.deregister(nodeID: "n1")
+        let found = await catalog.discover(serviceName: "svc")
         #expect(found == [i2])
     }
 }
@@ -141,7 +141,7 @@ struct InProcessServiceProviderTests {
         let provider = InProcessServiceProvider(nodeID: "node1")
         try await provider.host(service: GreeterService(), catalogue: catalog)
 
-        let found = try await catalog.discover(serviceName: "greeter")
+        let found = await catalog.discover(serviceName: "greeter")
         #expect(found.count == 1)
         if case .inProcess(let id) = found[0].endpoint {
             #expect(id == "node1/greeter")


### PR DESCRIPTION
…encoder

  AvroKeyedEncodingContainer.encode(_:Int,forKey:) rejected longSchema fields
  because it only checked isInt() — Swift Int is 64-bit and must also match
  isLong(). Added isLong() and a long-typed union-index fallback to the guard.

  AvroProtocol.getRequest/getResponse returned typeMap schemas with unresolved
  named-type references (unknownSchema), causing the encoder to fail on nested
  types. Added resolveRefs() to substitute references recursively before returning.

  Removed eight spurious try keywords from ServiceLayerTests calls on
  InMemoryCatalog, whose concrete methods don't throw.