### PR TITLE
Handle unions with arrays and other types.

### DIFF
--- a/Sources/SwiftAvroCore/Codable/AvroEncodable.swift
+++ b/Sources/SwiftAvroCore/Codable/AvroEncodable.swift
@@ -585,38 +585,70 @@ extension EncodingHelper {
         }
     }
 
+    /// Resolves a primitive value's schema when the array element / single value
+    /// is a union. Mirrors the record container's `encodeUnionIndex` for the
+    /// unkeyed & single-value paths: returns `true` when `schema` already matches
+    /// the primitive type; when `schema` is a union, writes the matching branch
+    /// index (so the caller can then write the value) and returns `true`;
+    /// returns `false` when there is no compatible branch.
+    private mutating func writePrimitiveUnionIndexIfNeeded(_ matches: (AvroSchema) -> Bool) -> Bool {
+        if matches(schema) {
+            return true
+        }
+        if case .unionSchema(let union) = schema,
+           let index = union.branches.firstIndex(where: matches) {
+            encoder.primitive.encode(index)
+            return true
+        }
+        return false
+    }
+
     mutating func encode(_ value: Bool) throws {
-        guard schema.isBoolean() else { throw BinaryEncodingError.typeMismatchWithSchemaBool }
+        guard writePrimitiveUnionIndexIfNeeded({ $0.isBoolean() }) else {
+            throw BinaryEncodingError.typeMismatchWithSchemaBool
+        }
         encoder.primitive.encode(value)
     }
 
     mutating func encode(_ value: Int) throws {
-        guard schema.isLong() else { throw BinaryEncodingError.typeMismatchWithSchemaInt }
+        guard writePrimitiveUnionIndexIfNeeded({ $0.isLong() }) else {
+            throw BinaryEncodingError.typeMismatchWithSchemaInt
+        }
         encoder.primitive.encode(value)
     }
 
     mutating func encode(_ value: Int8) throws {
-        guard schema.isInt() else { throw BinaryEncodingError.typeMismatchWithSchemaInt8 }
+        guard writePrimitiveUnionIndexIfNeeded({ $0.isInt() }) else {
+            throw BinaryEncodingError.typeMismatchWithSchemaInt8
+        }
         encoder.primitive.encode(value)
     }
 
     mutating func encode(_ value: Int16) throws {
-        guard schema.isInt() else { throw BinaryEncodingError.typeMismatchWithSchemaInt16 }
+        guard writePrimitiveUnionIndexIfNeeded({ $0.isInt() }) else {
+            throw BinaryEncodingError.typeMismatchWithSchemaInt16
+        }
         encoder.primitive.encode(value)
     }
 
     mutating func encode(_ value: Int32) throws {
-        guard schema.isInt() else { throw BinaryEncodingError.typeMismatchWithSchemaInt32 }
+        guard writePrimitiveUnionIndexIfNeeded({ $0.isInt() }) else {
+            throw BinaryEncodingError.typeMismatchWithSchemaInt32
+        }
         encoder.primitive.encode(value)
     }
 
     mutating func encode(_ value: Int64) throws {
-        guard schema.isLong() else { throw BinaryEncodingError.typeMismatchWithSchemaInt64 }
+        guard writePrimitiveUnionIndexIfNeeded({ $0.isLong() }) else {
+            throw BinaryEncodingError.typeMismatchWithSchemaInt64
+        }
         encoder.primitive.encode(value)
     }
 
     mutating func encode(_ value: UInt) throws {
-        guard schema.isLong() else { throw BinaryEncodingError.typeMismatchWithSchemaUInt }
+        guard writePrimitiveUnionIndexIfNeeded({ $0.isLong() }) else {
+            throw BinaryEncodingError.typeMismatchWithSchemaUInt
+        }
         try encoder.primitive.encode(value)
     }
 
@@ -630,7 +662,9 @@ extension EncodingHelper {
     }
 
     mutating func encode(_ value: UInt16) throws {
-        guard schema.isInt() else { throw BinaryEncodingError.typeMismatchWithSchemaInt16 }
+        guard writePrimitiveUnionIndexIfNeeded({ $0.isInt() }) else {
+            throw BinaryEncodingError.typeMismatchWithSchemaInt16
+        }
         encoder.primitive.encode(value)
     }
 
@@ -640,17 +674,47 @@ extension EncodingHelper {
     }
 
     mutating func encode(_ value: UInt64) throws {
-        guard schema.isLong() else { throw BinaryEncodingError.typeMismatchWithSchemaUInt64 }
+        guard writePrimitiveUnionIndexIfNeeded({ $0.isLong() }) else {
+            throw BinaryEncodingError.typeMismatchWithSchemaUInt64
+        }
         try encoder.primitive.encode(value)
     }
 
     mutating func encode(_ value: Float) throws {
-        guard schema.isFloat() else { throw BinaryEncodingError.typeMismatchWithSchemaFloat }
+        guard writePrimitiveUnionIndexIfNeeded({ $0.isFloat() }) else {
+            throw BinaryEncodingError.typeMismatchWithSchemaFloat
+        }
         encoder.primitive.encode(value)
     }
 
     mutating func encode(_ value: Double) throws {
-        switch schema {
+        // A `Double` may target a plain `double` schema or an `int`/`long` carrying
+        // a `date`/time logical type (a Swift `Date` encodes as a `Double`). When the
+        // element/field schema is a union, select whichever branch the direct path
+        // below can encode, write its index, and encode the value against that branch.
+        var effectiveSchema = schema
+        if case .unionSchema(let union) = schema {
+            if let index = union.branches.firstIndex(where: { branch in
+                if branch.isDouble() { return true }
+                if case .intSchema(let param) = branch,
+                   param.logicalType == .date || param.logicalType == .timeMillis {
+                    return true
+                }
+                if case .longSchema(let param) = branch,
+                   param.logicalType == .timeMicros
+                    || param.logicalType == .timestampMillis
+                    || param.logicalType == .timestampMicros {
+                    return true
+                }
+                return false
+            }) {
+                encoder.primitive.encode(index)
+                effectiveSchema = union.branches[index]
+            } else {
+                throw BinaryEncodingError.typeMismatchWithSchemaDouble
+            }
+        }
+        switch effectiveSchema {
         case .doubleSchema:
             encoder.primitive.encode(value)
         case .intSchema(let param) where param.logicalType == .date:
@@ -669,7 +733,30 @@ extension EncodingHelper {
     }
 
     mutating func encode(_ value: String) throws {
-        switch schema {
+        // A String targets a `string` branch or an `enum` branch (encoded by its
+        // symbol index). When the schema is a union, select whichever is present
+        // (preferring `string`), write its index, and encode against that branch.
+        // Previously the union case only matched a `string` branch and had no
+        // `else`, so an enum-only union silently encoded nothing.
+        var effectiveSchema = schema
+        if case .unionSchema(let union) = schema {
+            if let index = union.branches.firstIndex(where: {
+                if case .stringSchema = $0 { return true }
+                return false
+            }) {
+                encoder.primitive.encode(index)
+                effectiveSchema = union.branches[index]
+            } else if let index = union.branches.firstIndex(where: {
+                if case .enumSchema = $0 { return true }
+                return false
+            }) {
+                encoder.primitive.encode(index)
+                effectiveSchema = union.branches[index]
+            } else {
+                throw BinaryEncodingError.typeMismatchWithSchemaString
+            }
+        }
+        switch effectiveSchema {
         case .stringSchema(let param):
             if param.logicalType == .uuid {
                 guard UUID(uuidString: value) != nil else {
@@ -682,13 +769,6 @@ extension EncodingHelper {
                 throw BinaryEncodingError.typeMismatchWithSchemaString
             }
             encoder.primitive.encode(id)
-        case .unionSchema(let union):
-            if let id = union.branches.firstIndex(where: {
-                if case .stringSchema = $0 { return true }; return false
-            }) {
-                encoder.primitive.encode(id)
-                encoder.primitive.encode(value)
-            }
         default:
             throw BinaryEncodingError.typeMismatchWithSchemaString
         }

--- a/Tests/SwiftAvroCoreTests/AvroUnionArrayEncodingTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroUnionArrayEncodingTest.swift
@@ -1,0 +1,147 @@
+//
+//  AvroUnionArrayEncodingTest.swift
+//  SwiftAvroCoreTests
+//
+//  Regression tests for encoding non-nil values whose Avro item schema is a
+//  union — e.g. `array<union{null,long}>` (the shape of `JsmaEvent.intValues`).
+//
+//  The unkeyed / single-value encoders resolved union branches only for
+//  `String`; the numeric/bool scalar encoders did not. So a non-nil numeric
+//  element in a union-typed array threw `BinaryEncodingError` (e.g.
+//  `.typeMismatchWithSchemaInt64`) and the value was silently dropped. These
+//  tests fail against the broken encoder and pass once the numeric encoders
+//  learn union resolution.
+//
+//  Originally IOS-22148 (XCTest); converted to Swift Testing.
+//
+
+import Testing
+import Foundation
+@testable import SwiftAvroCore
+
+@Suite("Avro Union Array Encoding")
+struct AvroUnionArrayEncodingTests {
+
+    // MARK: - Demonstrates the bug (fails until the numeric encoders resolve unions)
+
+    /// `array<union{null,long}>` with a non-nil element — the exact production shape.
+    /// Previously threw `typeMismatchWithSchemaInt64`.
+    @Test("array<union{null,long}> encodes a non-nil element")
+    func encodeArrayOfNullableLong_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null","long"]}"#))
+        let data = try AvroEncoder().encode([Int64(1)], schema: schema)
+        // block count = 1 (0x02), union branch index = 1/long (0x02),
+        // value = 1 (0x02), end-of-array block (0x00)
+        #expect(data == Data([0x02, 0x02, 0x02, 0x00]))
+    }
+
+    /// `array<union{null,int}>` with a non-nil element.
+    @Test("array<union{null,int}> encodes a non-nil element")
+    func encodeArrayOfNullableInt_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null","int"]}"#))
+        _ = try AvroEncoder().encode([Int32(1)], schema: schema)
+    }
+
+    /// `array<union{null,boolean}>` with a non-nil element.
+    @Test("array<union{null,boolean}> encodes a non-nil element")
+    func encodeArrayOfNullableBoolean_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null","boolean"]}"#))
+        _ = try AvroEncoder().encode([true], schema: schema)
+    }
+
+    // MARK: - Controls that already passed (prove the defect was numeric-specific)
+
+    /// String union arrays already encode — `encode(String)` resolved the union.
+    @Test("array<union{null,string}> encodes a non-nil element")
+    func encodeArrayOfNullableString_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null","string"]}"#))
+        _ = try AvroEncoder().encode(["x"], schema: schema)
+    }
+
+    /// Nil elements already encode — `encodeNil()` resolved the union.
+    @Test("array<union{null,long}> encodes a nil element")
+    func encodeArrayOfNullableLong_nilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null","long"]}"#))
+        _ = try AvroEncoder().encode([Int64?.none], schema: schema)
+    }
+
+    // MARK: - Float / Double union coverage
+
+    @Test("array<union{null,float}> encodes a non-nil element")
+    func encodeArrayOfNullableFloat_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null","float"]}"#))
+        _ = try AvroEncoder().encode([Float(1.5)], schema: schema)
+    }
+
+    @Test("array<union{null,double}> encodes a non-nil element")
+    func encodeArrayOfNullableDouble_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null","double"]}"#))
+        _ = try AvroEncoder().encode([Double(2.5)], schema: schema)
+    }
+
+    // MARK: - Double via a logical-type (date) branch inside a union
+    //
+    // A Swift `Date` encodes as a Double, which the direct path maps onto an
+    // `int` schema carrying `logicalType: "date"`. The union path must select
+    // that branch too — not just a plain `double` branch.
+
+    /// `array<union{null, int/date}>` with a non-nil `Date`.
+    @Test("array<union{null,int/date}> encodes a non-nil Date")
+    func encodeArrayOfNullableDate_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null",{"type":"int","logicalType":"date"}]}"#))
+        _ = try AvroEncoder().encode([Date(timeIntervalSince1970: 0)], schema: schema)
+    }
+
+    // A Double must also resolve to the remaining Double-encodable logical-type
+    // branches inside a union — int/time-millis and long/time-micros,
+    // timestamp-millis, timestamp-micros — not just double and int/date.
+
+    @Test("array<union{null,int/time-millis}> encodes a non-nil element")
+    func encodeArrayOfNullableTimeMillis_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null",{"type":"int","logicalType":"time-millis"}]}"#))
+        _ = try AvroEncoder().encode([Double(0)], schema: schema)
+    }
+
+    @Test("array<union{null,long/time-micros}> encodes a non-nil element")
+    func encodeArrayOfNullableTimeMicros_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null",{"type":"long","logicalType":"time-micros"}]}"#))
+        _ = try AvroEncoder().encode([Double(0)], schema: schema)
+    }
+
+    @Test("array<union{null,long/timestamp-millis}> encodes a non-nil element")
+    func encodeArrayOfNullableTimestampMillis_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null",{"type":"long","logicalType":"timestamp-millis"}]}"#))
+        _ = try AvroEncoder().encode([Double(0)], schema: schema)
+    }
+
+    @Test("array<union{null,long/timestamp-micros}> encodes a non-nil element")
+    func encodeArrayOfNullableTimestampMicros_nonNilElement() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"{"type":"array","items":["null",{"type":"long","logicalType":"timestamp-micros"}]}"#))
+        _ = try AvroEncoder().encode([Double(0)], schema: schema)
+    }
+
+    // MARK: - String union: enum branch + no-matching-branch
+    //
+    // The String union path only matched a `string` branch and had no `else`,
+    // so an enum-only union silently encoded NOTHING (worse than throwing).
+
+    /// `union{null, enum}` with a valid symbol. Previously a silent no-op
+    /// (encoded empty), so the byte assertion — not a no-throw check — exposes it.
+    @Test("union{null,enum} encodes a non-nil symbol")
+    func encodeNullableEnum_nonNil() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"["null",{"type":"enum","name":"Suit","symbols":["A","B","C"]}]"#))
+        let data = try AvroEncoder().encode("B", schema: schema)
+        // union branch index = 1/enum (0x02), enum symbol index for "B" = 1 (0x02)
+        #expect(data == Data([0x02, 0x02]))
+    }
+
+    /// A String against a union with no string/enum branch must throw, not
+    /// silently encode nothing.
+    @Test("String against a non-string/enum union throws")
+    func encodeString_againstNonStringUnion_throws() throws {
+        let schema = try #require(Avro().decodeSchema(schema: #"["null","long"]"#))
+        #expect(throws: (any Error).self) {
+            _ = try AvroEncoder().encode("x", schema: schema)
+        }
+    }
+}


### PR DESCRIPTION
When a there is a union with arrays and non-strings, SwiftAvroCore refuses to encode. Example string that fails: `array<union{null,long}>)`.