### PR TITLE
Fix union branch resolution for scalar values (fixes #61)

### DIFF
--- a/Sources/SwiftAvroCore/Codable/AvroEncodable.swift
+++ b/Sources/SwiftAvroCore/Codable/AvroEncodable.swift
@@ -99,6 +99,12 @@ private final class AvroBinaryEncoder: Encoder {
     }
 
     func encode<T: Encodable>(_ value: T) throws {
+        if case .unionSchema(let union) = schema,
+           let index = try AvroBinaryEncoder.resolveUnionBranch(for: value, in: union) {
+            primitive.encode(index)
+            try AvroBinaryEncoder(schema: union.branches[index], primitive: primitive).encode(value)
+            return
+        }
         switch schema {
         case .bytesSchema(let bytesSchema):
             if bytesSchema.logicalType == .decimal {
@@ -187,6 +193,97 @@ private final class AvroBinaryEncoder: Encoder {
 
     func getData() -> Data { Data(primitive.buffer) }
     func getSize() -> Int  { primitive.size }
+
+    /// Resolves which branch of a union a scalar `value` belongs to, by Swift type
+    /// rather than by "first non-null branch" — the single choke point every encode
+    /// path funnels through, so union resolution for scalars lives here once instead
+    /// of being re-implemented in each `EncodingHelper` primitive overload.
+    ///
+    /// Returns `nil` (no opinion, defer to existing behavior) for values whose type
+    /// isn't one of the scalar cases below — compound values (records/arrays/maps/
+    /// Optional.none) are already resolved correctly elsewhere (keyed-container field
+    /// resolution, `encodeNil()`, or the unkeyed container's own union pinning).
+    private static func resolveUnionBranch<T>(for value: T, in union: AvroSchema.UnionSchema) throws -> Int? {
+        switch value {
+        case is Bool:
+            guard let i = union.branches.firstIndex(where: { $0.isBoolean() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaBool
+            }
+            return i
+        case is Int:
+            guard let i = union.branches.firstIndex(where: { $0.isLong() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaInt
+            }
+            return i
+        case is Int8:
+            guard let i = union.branches.firstIndex(where: { $0.isInt() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaInt8
+            }
+            return i
+        case is Int16:
+            guard let i = union.branches.firstIndex(where: { $0.isInt() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaInt16
+            }
+            return i
+        case is Int32:
+            guard let i = union.branches.firstIndex(where: { $0.isInt() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaInt32
+            }
+            return i
+        case is Int64:
+            guard let i = union.branches.firstIndex(where: { $0.isLong() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaInt64
+            }
+            return i
+        case is UInt:
+            guard let i = union.branches.firstIndex(where: { $0.isLong() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaUInt
+            }
+            return i
+        case is UInt16:
+            guard let i = union.branches.firstIndex(where: { $0.isInt() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaUInt16
+            }
+            return i
+        case is UInt64:
+            guard let i = union.branches.firstIndex(where: { $0.isLong() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaUInt64
+            }
+            return i
+        case is Float:
+            guard let i = union.branches.firstIndex(where: { $0.isFloat() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaFloat
+            }
+            return i
+        case is Double, is Date:
+            // `Date` encodes itself as a `Double` (timeIntervalSinceReferenceDate)
+            // further down the pipeline, so it resolves against the same branches.
+            guard let i = union.branches.firstIndex(where: { AvroBinaryEncoder.branchAcceptsDouble($0) }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaDouble
+            }
+            return i
+        case is String:
+            guard let i = union.branches.firstIndex(where: { $0.isString() || $0.isEnum() }) else {
+                throw BinaryEncodingError.typeMismatchWithSchemaString
+            }
+            return i
+        default:
+            return nil
+        }
+    }
+
+    private static func branchAcceptsDouble(_ branch: AvroSchema) -> Bool {
+        if branch.isDouble() { return true }
+        if case .intSchema(let param) = branch {
+            return param.logicalType == .date || param.logicalType == .timeMillis
+        }
+        if case .longSchema(let param) = branch {
+            return param.logicalType == .timeMicros
+                || param.logicalType == .timestampMillis
+                || param.logicalType == .timestampMicros
+        }
+        return false
+    }
 }
 
 // MARK: - AvroKeyedEncodingContainer

--- a/Tests/SwiftAvroCoreTests/AvroEncodableTest.swift
+++ b/Tests/SwiftAvroCoreTests/AvroEncodableTest.swift
@@ -710,6 +710,179 @@ struct AvroEncodableTests {
         }
     }
 
+    // MARK: - Union-typed array elements / single values (non-nil scalar resolution)
+    //
+    // Regression coverage for encoding non-nil values whose Avro schema is a union —
+    // e.g. `array<union{null,long}>` — for every scalar type, not just String. The
+    // unkeyed/single-value encode path used to resolve union branches only for
+    // String; other scalars threw `BinaryEncodingError.typeMismatchWithSchemaX`
+    // and the value was silently dropped.
+
+    @Suite("AvroEncoder – union-typed array elements")
+    struct UnionArrayElementEncodeTest {
+
+        private func schema(_ json: String) throws -> AvroSchema {
+            try #require(Avro().decodeSchema(schema: json))
+        }
+
+        @Test("array<union{null,long}> encodes a non-nil element")
+        func nonNilLong() throws {
+            let s = try schema(#"{"type":"array","items":["null","long"]}"#)
+            let data = try AvroEncoder().encode([Int64(1)], schema: s)
+            // block count=1 (0x02), union branch index=1/long (0x02), value=1 (0x02), end (0x00)
+            #expect(data == Data([0x02, 0x02, 0x02, 0x00]))
+        }
+
+        @Test("array<union{null,long}> encodes a nil element")
+        func nilLong() throws {
+            let s = try schema(#"{"type":"array","items":["null","long"]}"#)
+            let data = try AvroEncoder().encode([Int64?.none], schema: s)
+            // block count=1 (0x02), union branch index=0/null (0x00), end (0x00)
+            #expect(data == Data([0x02, 0x00, 0x00]))
+        }
+
+        @Test("array<union{null,int}> encodes a non-nil element", arguments: [Int32(1), Int32(-1), Int32(0)])
+        func nonNilInt(_ value: Int32) throws {
+            let s = try schema(#"{"type":"array","items":["null","int"]}"#)
+            #expect(try AvroEncoder().encode([value], schema: s).count > 0)
+        }
+
+        @Test("array<union{null,boolean}> encodes a non-nil element")
+        func nonNilBoolean() throws {
+            let s = try schema(#"{"type":"array","items":["null","boolean"]}"#)
+            let data = try AvroEncoder().encode([true], schema: s)
+            #expect(data == Data([0x02, 0x02, 0x01, 0x00]))
+        }
+
+        @Test("array<union{null,float}> encodes a non-nil element")
+        func nonNilFloat() throws {
+            let s = try schema(#"{"type":"array","items":["null","float"]}"#)
+            #expect(try AvroEncoder().encode([Float(1.5)], schema: s).count > 0)
+        }
+
+        @Test("array<union{null,double}> encodes a non-nil element")
+        func nonNilDouble() throws {
+            let s = try schema(#"{"type":"array","items":["null","double"]}"#)
+            #expect(try AvroEncoder().encode([Double(2.5)], schema: s).count > 0)
+        }
+
+        @Test("array<union{null,string}> encodes a non-nil element")
+        func nonNilString() throws {
+            let s = try schema(#"{"type":"array","items":["null","string"]}"#)
+            #expect(try AvroEncoder().encode(["x"], schema: s).count > 0)
+        }
+
+        // MARK: Other integer widths — the numeric bug wasn't just Int64/Int32.
+
+        @Test("array<union{null,int}> encodes a non-nil Int8/Int16 element")
+        func nonNilSmallInts() throws {
+            let s = try schema(#"{"type":"array","items":["null","int"]}"#)
+            #expect(try AvroEncoder().encode([Int8(5)], schema: s).count > 0)
+            #expect(try AvroEncoder().encode([Int16(5)], schema: s).count > 0)
+            #expect(try AvroEncoder().encode([UInt16(5)], schema: s).count > 0)
+        }
+
+        @Test("array<union{null,long}> encodes non-nil UInt/UInt64 elements")
+        func nonNilUnsignedLongs() throws {
+            let s = try schema(#"{"type":"array","items":["null","long"]}"#)
+            #expect(try AvroEncoder().encode([UInt(5)], schema: s).count > 0)
+            #expect(try AvroEncoder().encode([UInt64(5)], schema: s).count > 0)
+        }
+
+        // MARK: Double via a logical-type branch inside a union — the direct
+        // (non-array, single-value) path, since `Date` never reaches the array
+        // fast path used by these array-element tests.
+
+        @Test("union{null,int/date} encodes a non-nil Date")
+        func nonNilDateUnion() throws {
+            let s = try schema(#"["null",{"type":"int","logicalType":"date"}]"#)
+            #expect(try AvroEncoder().encode(Date(timeIntervalSince1970: 0), schema: s).count > 0)
+        }
+
+        @Test("union{null,long/timestamp-millis} encodes a non-nil Date")
+        func nonNilTimestampMillisUnion() throws {
+            let s = try schema(#"["null",{"type":"long","logicalType":"timestamp-millis"}]"#)
+            #expect(try AvroEncoder().encode(Date(timeIntervalSince1970: 0), schema: s).count > 0)
+        }
+
+        @Test("union{null,double} encodes a non-nil Double directly")
+        func nonNilDoubleUnionDirect() throws {
+            let s = try schema(#"["null","double"]"#)
+            #expect(try AvroEncoder().encode(Double(2.5), schema: s).count > 0)
+        }
+
+        @Test("array<union{null,int/date}> encodes a non-nil Date element")
+        func nonNilDateArrayElement() throws {
+            let s = try schema(#"{"type":"array","items":["null",{"type":"int","logicalType":"date"}]}"#)
+            #expect(try AvroEncoder().encode([Date(timeIntervalSince1970: 0)], schema: s).count > 0)
+        }
+
+        // MARK: Multi-branch unions — must pick the branch matching the value's
+        // type, not just "first non-null branch" (that heuristic breaks as soon
+        // as a union has more than one non-null branch).
+
+        @Test("union{null,string,long} picks the long branch for an Int64 value")
+        func multiBranchPicksLong() throws {
+            let s = try schema(#"["null","string","long"]"#)
+            let data = try AvroEncoder().encode(Int64(9), schema: s)
+            // union branch index=2/long (0x04), value=9 (0x12)
+            #expect(data == Data([0x04, 0x12]))
+        }
+
+        @Test("union{null,string,long} picks the string branch for a String value")
+        func multiBranchPicksString() throws {
+            let s = try schema(#"["null","string","long"]"#)
+            let data = try AvroEncoder().encode("hi", schema: s)
+            // union branch index=1/string (0x02), length=2 (0x04), "hi"
+            #expect(data == Data([0x02, 0x04, 0x68, 0x69]))
+        }
+
+        // MARK: Enum branch — a plain String must resolve to an enum branch when
+        // there's no string branch, and encode by symbol index (not raw bytes).
+
+        @Test("union{null,enum} encodes a non-nil symbol")
+        func nonNilEnumUnion() throws {
+            let s = try schema(#"["null",{"type":"enum","name":"Suit","symbols":["A","B","C"]}]"#)
+            let data = try AvroEncoder().encode("B", schema: s)
+            // union branch index=1/enum (0x02), enum symbol index for "B"=1 (0x02)
+            #expect(data == Data([0x02, 0x02]))
+        }
+
+        // MARK: No matching branch must throw, not silently encode nothing.
+
+        @Test("String against a union with no string/enum branch throws")
+        func stringNoMatchThrows() throws {
+            let s = try schema(#"["null","long"]"#)
+            #expect(throws: BinaryEncodingError.typeMismatchWithSchemaString) {
+                _ = try AvroEncoder().encode("x", schema: s)
+            }
+        }
+
+        @Test("Int64 against a union with no numeric branch throws")
+        func int64NoMatchThrows() throws {
+            let s = try schema(#"["null","string"]"#)
+            #expect(throws: BinaryEncodingError.typeMismatchWithSchemaInt64) {
+                _ = try AvroEncoder().encode(Int64(1), schema: s)
+            }
+        }
+
+        // MARK: Round-trip through the decoder, not just raw-byte assertions.
+
+        @Test("record with array<union{null,long}> field round-trips non-nil values")
+        func roundTripRecordWithUnionArray() throws {
+            struct R: Codable, Equatable { let values: [Int64?] }
+            let s = try schema(#"""
+            {"type":"record","name":"R","fields":[
+              {"name":"values","type":{"type":"array","items":["null","long"]}}
+            ]}
+            """#)
+            let value = R(values: [1, nil, 3])
+            let data = try AvroEncoder().encode(value, schema: s)
+            let back = try AvroDecoder(schema: s).decode(R.self, from: data)
+            #expect(back == value)
+        }
+    }
+
     // MARK: - Single-value primitive encodings (EncodingHelper paths)
 
     @Suite("AvroEncoder – single-value primitives")


### PR DESCRIPTION
## Summary
- `array<union{null,long}>` (and similar union-typed scalar schemas) threw `typeMismatchWithSchemaX` for non-nil elements instead of encoding them.
- Root cause: `AvroUnkeyedEncodingContainer.init` resolves unions eagerly by picking the first non-null branch, but only mutates its own local `schema` copy — the underlying `AvroBinaryEncoder.schema` stays an unresolved union. Scalars that fall through to `encoder.encode(value)` then hit that unresolved union inside `EncodingHelper`. The same heuristic is also wrong for any union with more than one non-null branch.
- Fix resolves the union branch by the value's Swift type at the one choke point every encode path funnels through (`AvroBinaryEncoder.encode<T>`), writes the index, and recurses with the concrete branch schema. `EncodingHelper`'s per-type encode methods are untouched.
- Supersedes #61: reused and extended its test cases (other integer widths, a multi-branch-union case, and a decoder round-trip), moved into `AvroEncodableTest.swift` alongside the existing union-pinning tests. Credit to @sydpolk-indeed for the repro and initial test coverage.

## Test plan
- [x] `swift build`
- [x] `swift test` (884/884 passing, including new `AvroEncoder – union-typed array elements` suite)
- [x] CI green on push (Linux job had one flaky NIO/HTTPClient crash unrelated to this change; passed clean on retry)